### PR TITLE
Add agent-facing documentation and knowledge base

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,131 @@
+# Architecture
+
+## System Overview
+
+stats-go is a set of Go services for ranking college football teams. Data flows
+in one direction: ESPN API -> parsing -> database -> ranking algorithm -> output.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                      ESPN HTTP API                       │
+└──────────────────────────┬──────────────────────────────┘
+                           │
+              ┌────────────▼────────────┐
+              │     internal/espn       │  Pure HTTP client
+              │  (schedules, stats,     │  No DB dependency
+              │   team info)            │
+              └────────────┬────────────┘
+                           │
+              ┌────────────▼────────────┐
+              │     internal/game       │  Parses ESPN responses
+              │     internal/team       │  into DB model structs
+              └────────────┬────────────┘
+                           │
+              ┌────────────▼────────────┐
+              │   internal/database     │  GORM models (14 tables)
+              │  (Postgres or SQLite)   │  Shared by all services
+              └────────────┬────────────┘
+                           │
+          ┌────────────────┼────────────────┐
+          │                │                │
+   ┌──────▼──────┐  ┌─────▼──────┐  ┌──────▼──────┐
+   │  internal/   │  │ internal/  │  │  internal/  │
+   │  ranking     │  │ updater    │  │  writer     │
+   │  (algorithm) │  │ (orchestr) │  │ (interface) │
+   └──────────────┘  └────────────┘  └─────────────┘
+          │                │                │
+          │         ┌──────┴──────┐         │
+          │         │  Uses both  │─────────┘
+          │         └─────────────┘
+          │
+   ┌──────┴──────────────────────────────────┐
+   │              cmd/ entry points           │
+   │  ranker     updater     migrate          │
+   └──────────────────────────────────────────┘
+```
+
+## Package Dependency Rules
+
+Dependencies flow **downward only**. Packages must not import from peers at the
+same level or from `cmd/`.
+
+```
+cmd/ranker   → config, database, ranking
+cmd/updater  → config, database, logger, updater, writer
+cmd/migrate  → database
+
+updater      → database, espn, game, ranking, team, writer
+game         → database, espn
+team         → espn
+ranking      → database
+writer       → (external: AWS SDK, DO API)
+espn         → (external: net/http only)
+config       → (external: godotenv)
+logger       → (external: zap)
+database     → (external: gorm)
+```
+
+## Key Abstractions
+
+### Writer Interface
+
+```go
+type Writer interface {
+    WriteData(ctx context.Context, fileName string, data any) error
+    PurgeCache(ctx context.Context) error
+}
+```
+
+Two implementations:
+- **DigitalOceanWriter** — uploads gzipped JSON to DO Spaces, purges CDN cache
+- **DefaultWriter** — writes JSON to local filesystem
+
+### Updater Struct
+
+Central orchestrator that ties together all internal packages:
+
+```go
+type Updater struct {
+    DB     *gorm.DB
+    Logger *zap.SugaredLogger
+    Writer writer.Writer
+}
+```
+
+Responsible for: fetching games, updating the DB, computing rankings, and
+exporting JSON. Used by `cmd/updater` in both scheduled and on-demand modes.
+
+### Ranker Struct
+
+```go
+type Ranker struct {
+    DB   *gorm.DB
+    Year int64
+    Week int64
+    Fcs  bool
+}
+```
+
+Executes the ranking pipeline: `setup → record → srs → sos → finalRanking`.
+All computation happens in-memory after initial DB queries.
+
+### ESPN Client
+
+Stateless HTTP client. All functions are package-level (no struct). URLs are
+package-level vars so tests can override them with a mock HTTP server.
+
+## Database
+
+14 GORM models covering teams, games, and player statistics. Supports both
+PostgreSQL (production) and SQLite (local development). Connection is determined
+by whether `DBParams` is nil (nil → SQLite).
+
+All models use composite primary keys for multi-dimensional lookups
+(team+year, game+team, etc.).
+
+## Deployment
+
+- **Docker:** Multi-stage build (`golang:1.21-alpine` → `alpine:latest`)
+- **Production:** `updater -schedule` running in a container alongside PostgreSQL
+- **CI/CD:** GitHub Actions — lint and test on PR, build+push on merge to master
+- **Output:** JSON files served from DigitalOcean Spaces CDN

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# stats-go
+
+College football computer ranking system written in Go. Collects game data from
+ESPN, computes rankings using a composite algorithm, and exports results to
+DigitalOcean Spaces.
+
+## Quick Reference
+
+- **Language:** Go 1.21
+- **Module:** `github.com/robby-barton/stats-go`
+- **Build/Run:** `make ranker`, `make updater`
+- **Test:** `go test ./...`
+- **Lint:** `golangci-lint run --config=.golangci.yml ./cmd/... ./internal/...`
+- **Format:** `go fmt ./...` (goimports enforced via golangci-lint)
+
+## Repository Layout
+
+```
+cmd/
+  ranker/     CLI tool to calculate and print rankings
+  updater/    Service that fetches games and updates DB/JSON on a schedule
+  migrate/    One-time migration from PostgreSQL to SQLite
+internal/
+  config/     Environment-based configuration (godotenv)
+  database/   GORM models and DB initialization (Postgres + SQLite)
+  espn/       ESPN API client (game schedules, stats, team info)
+  game/       Game data parsing and stat extraction
+  logger/     Structured logging (zap)
+  ranking/    Ranking algorithm (SRS, SOS, composite scoring)
+  team/       Team info parsing from ESPN
+  updater/    Orchestration of DB updates and JSON export
+  writer/     Output interface with DigitalOcean and local implementations
+```
+
+## Architecture
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the full dependency graph and design
+rationale.
+
+Key patterns:
+- **Three independent CLI entry points** in `cmd/` — each wires its own deps
+- **Writer interface** (`internal/writer`) — pluggable output (DO Spaces vs local files)
+- **Updater struct** receives DB, Logger, and Writer via dependency injection
+- **ESPN package** is a pure HTTP client with no DB dependency
+- **Ranking package** takes a `*gorm.DB` and computes everything in-memory
+
+## Conventions
+
+- All database access goes through GORM. Transactions are manually managed
+  (`SkipDefaultTransaction: true`).
+- Use `go.uber.org/zap` SugaredLogger for all logging. No `fmt.Println` outside
+  of the ranker CLI output (enforced via `forbidigo` lint).
+- Errors are propagated up — panics are only recovered at the scheduler level
+  in `cmd/updater`.
+- ESPN API calls use a 200ms sleep between requests for rate limiting (in `game/`).
+- The HTTP client in `espn/request.go` retries up to 5 times with 1s backoff.
+- Test files use `_test.go` suffix. ESPN tests use a mock HTTP server pattern
+  with fixture data.
+- `nolint` directives require both a specific linter and an explanation
+  (`require-explanation: true`, `require-specific: true`).
+
+## Deeper Documentation
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — package dependencies and layering
+- [docs/design-decisions.md](docs/design-decisions.md) — rationale for key choices
+- [docs/espn-api.md](docs/espn-api.md) — ESPN endpoints and data shapes
+- [docs/tech-debt.md](docs/tech-debt.md) — known issues and improvement areas

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,19 @@ Key patterns:
 - `nolint` directives require both a specific linter and an explanation
   (`require-explanation: true`, `require-specific: true`).
 
+## Golden Rule: Keep Documentation Up to Date
+
+Any change that alters architecture, package dependencies, public interfaces,
+ESPN API usage, conventions, or design rationale **must** include corresponding
+updates to the relevant docs (`CLAUDE.md`, `ARCHITECTURE.md`, or files in
+`docs/`). Documentation that contradicts the code is worse than no documentation
+at all — it actively misleads future work.
+
+When in doubt, update the docs. When adding a new package or changing how an
+existing one works, update `ARCHITECTURE.md`. When making a deliberate tradeoff,
+record it in `docs/design-decisions.md`. When discovering or resolving tech
+debt, update `docs/tech-debt.md`.
+
 ## Deeper Documentation
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) — package dependencies and layering

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1,0 +1,81 @@
+# Design Decisions
+
+## Ranking Algorithm: 60/30/10 Composite
+
+The final ranking uses a weighted composite score:
+
+```
+FinalRaw = (Record * 0.60) + (SRS_normalized * 0.30) + (SOS_normalized * 0.10)
+```
+
+- **60% Win-Loss Record** — The most important factor. Teams that win more
+  games should rank higher.
+- **30% SRS (Simple Rating System)** — An iterative margin-of-victory rating
+  adjusted for opponent strength. Run with two margin-of-victory caps (1 and 30)
+  and averaged. The dual-MOV approach balances "did you win?" (MOV=1) with
+  "did you dominate?" (MOV=30) while preventing blowouts from distorting ratings.
+  Iterates up to 10,000 times or until convergence.
+- **10% SOS (Strength of Schedule)** — Solved via Cholesky decomposition of a
+  system of linear equations. Measures quality of opponents independent of the
+  team's own performance.
+
+All component scores are min-max normalized to [0,1] before weighting.
+
+## SRS Backfill: The James Madison Problem
+
+When a team transitions divisions (e.g., JMU moving to FBS in 2022), they may
+have very few intra-division games early in the season. The SRS algorithm
+requires a minimum of 12 games (`requiredGames`) per team. If a team has fewer,
+games from up to 2 previous seasons (`yearsBack`) are included. If still short,
+a targeted backfill query fetches additional historical games. This prevents
+small sample sizes from distorting the entire rating scale.
+
+See `internal/ranking/rating.go:199-228`.
+
+## Dual Database Support (PostgreSQL + SQLite)
+
+- **PostgreSQL** is used in production (DigitalOcean managed database).
+- **SQLite** is used for local development and the ranker CLI, avoiding the need
+  for a running Postgres instance.
+- The choice is implicit: if `DBParams` is nil (no PG env vars), SQLite is used.
+- Both use `SkipDefaultTransaction: true` because all transactions are managed
+  explicitly where needed.
+
+## ESPN API as Data Source
+
+ESPN provides unofficial JSON endpoints that return game schedules, box scores,
+and team metadata. These are undocumented public APIs used by ESPN's own
+frontend. See [espn-api.md](espn-api.md) for endpoint details.
+
+Key design choices:
+- **Filter on `STATUS_FINAL` only** — Only completed games are ingested to
+  avoid partial data.
+- **200ms rate limiting** between sequential API calls (in `game/` package) to
+  avoid being blocked.
+- **5 retries with 1s backoff** on HTTP failures (in `espn/request.go`).
+- **URL vars instead of constants** — ESPN endpoint URLs are `var` not `const`
+  so tests can override them with a mock HTTP server.
+
+## Writer Interface for Output
+
+Rather than hardcoding DigitalOcean Spaces, output goes through a `Writer`
+interface. This allows:
+- Production: gzipped JSON uploaded to DO Spaces with CDN cache purging
+- Local dev: plain JSON files written to disk
+- Testing: mock writers
+
+## Scheduled Updates During Football Season
+
+The updater runs on cron schedules scoped to football season months (Aug-Jan):
+- **Every 5 minutes:** Check for newly completed games
+- **Sundays at 5am:** Refresh team metadata
+- **August 10th at 6am:** Initialize the new season
+
+This avoids wasting resources during the offseason while ensuring near-real-time
+updates during games.
+
+## Panic Recovery in Scheduler
+
+Each scheduled task is wrapped in `defer recover()`. A panic in one update cycle
+(e.g., ESPN returning unexpected data) should not crash the long-running
+scheduler process. Errors are logged via zap and the next cycle runs normally.

--- a/docs/espn-api.md
+++ b/docs/espn-api.md
@@ -1,0 +1,92 @@
+# ESPN API Reference
+
+ESPN does not publish official documentation for these endpoints. They are
+reverse-engineered from ESPN's web frontend and may change without notice.
+
+## Endpoints
+
+### Game Schedule
+
+```
+GET https://cdn.espn.com/core/college-football/schedule
+    ?xhr=1&render=false&userab=18
+    [&year={year}]
+    [&week={week}]
+    [&group={group}]
+    [&seasonType={seasonType}]
+```
+
+Returns the schedule for a given week/year. Without parameters, returns the
+current week.
+
+**Response shape:** `GameScheduleESPN`
+- `Content.Schedule` — map of dates to game lists
+- `Content.Calendar` — season calendar with week boundaries
+- `Content.Calendar[1].StartDate` — postseason start date
+- `Content.Defaults.Year` — current default season year
+- `Content.ConferenceAPI.Conferences` — conference metadata
+
+**Used by:** `GetCurrentWeekGames`, `GetGamesByWeek`, `GetCompletedGamesByWeek`,
+`GetWeeksInSeason`, `HasPostseasonStarted`, `DefaultSeason`, `ConferenceMap`,
+`TeamConferencesByYear`
+
+### Game Stats / Play-by-Play
+
+```
+GET https://cdn.espn.com/core/college-football/playbyplay
+    ?gameId={gameID}&xhr=1&render=false&userab=18
+```
+
+Returns detailed game info including box score, team stats, and player stats
+for a single game.
+
+**Response shape:** `GameInfoESPN`
+- `GamePackage.Header` — game metadata (date, teams, scores, venue)
+- `GamePackage.BoxScore.Teams` — team-level statistics
+- `GamePackage.BoxScore.Players` — player-level stat categories
+
+**Used by:** `GetGameStats`
+
+### Team Info
+
+```
+GET https://site.api.espn.com/apis/site/v2/sports/football/college-football/teams
+    ?limit=1000
+```
+
+Returns metadata for all college football teams.
+
+**Response shape:** `TeamInfoESPN`
+- Team ID, abbreviation, display name, nickname
+- Colors (primary, alternate)
+- Logos (light and dark variants, max 2 per team)
+- Location info
+
+**Used by:** `GetTeamInfo`
+
+## Division Group IDs
+
+| Division | Group ID | Constant |
+|----------|----------|----------|
+| FBS      | 80       | `espn.FBS` |
+| FCS      | 81       | `espn.FCS` |
+| D-II     | 57       | `espn.DII` |
+| D-III    | 58       | `espn.DIII` |
+
+## Season Types
+
+| Type       | Value | Constant |
+|------------|-------|----------|
+| Regular    | 2     | `espn.Regular` |
+| Postseason | 3     | `espn.Postseason` |
+
+## Game Completion Filter
+
+Only games with `Status.StatusType.Completed == true` AND
+`Status.StatusType.Name == "STATUS_FINAL"` are considered complete.
+
+## Testing Pattern
+
+ESPN tests override the package-level URL vars to point at a local
+`httptest.Server` that serves fixture JSON. This avoids hitting the real API
+in tests while validating the full parsing pipeline.

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -1,0 +1,37 @@
+# Tech Debt Tracker
+
+## Active
+
+### Dependency versions are dated
+Go 1.21 and several dependencies (gorm, zap, aws-sdk-go v1, gocron v1) have
+newer major versions available. Upgrading would bring performance improvements
+and security patches. `aws-sdk-go` v1 is in maintenance mode; v2 is the
+supported path forward.
+
+### No integration tests
+Unit tests cover ESPN parsing, ranking math, and record formatting. There are no
+integration tests that exercise the full pipeline (fetch → parse → store →
+rank → export) against a real or in-memory database.
+
+### ESPN API fragility
+The ESPN endpoints are undocumented and could change at any time. There is no
+contract validation or schema checking on API responses — if ESPN changes a
+field name or nests data differently, it will fail at JSON decode time with a
+potentially unclear error.
+
+### Updater CLI flag surface area
+`cmd/updater/main.go` has grown to 8 boolean flags and a mix of scheduling and
+one-shot modes in a single `main()`. This could be clearer with subcommands
+(e.g., `updater schedule`, `updater games --all`).
+
+### Hard-coded rate limiting
+The 200ms sleep in `game/` and 1s retry backoff in `espn/request.go` are
+hard-coded. These could be configurable or use exponential backoff.
+
+### Home field advantage constant unused in final ranking
+`rating.go` defines `hfa = 3` (home field advantage) but it is not currently
+used in any calculation. Unclear if this is intentional or vestigial.
+
+## Resolved
+
+_(None yet — add entries here as debt is paid down.)_


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` as a concise agent entry point (~65 lines) with repo overview, build commands, conventions, and pointers to deeper docs
- Add `ARCHITECTURE.md` with package dependency graph, layering rules, and key abstractions (Writer, Updater, Ranker, ESPN client)
- Add `docs/` knowledge base:
  - `design-decisions.md` — rationale for the 60/30/10 ranking formula, James Madison backfill, dual DB support, ESPN strategy, scheduling
  - `espn-api.md` — all three ESPN endpoints, request/response shapes, group IDs, testing patterns
  - `tech-debt.md` — tracked active debt (dated deps, missing integration tests, ESPN fragility, CLI flag sprawl, etc.)

Inspired by [OpenAI's harness engineering](https://openai.com/index/harness-engineering/) approach: treat agent instructions as a table of contents, not an encyclopedia, with structured docs as the system of record.

## Test plan
- [ ] Verify all markdown links between files resolve correctly
- [ ] Confirm no impact on build/test/lint (`go test ./...`, `make lint`)