### PR TITLE
Add ESPN API response validation and error handling

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -7,11 +7,11 @@ Unit tests cover ESPN parsing, ranking math, and record formatting. There are no
 integration tests that exercise the full pipeline (fetch → parse → store →
 rank → export) against a real or in-memory database.
 
-### ESPN API fragility
-The ESPN endpoints are undocumented and could change at any time. There is no
-contract validation or schema checking on API responses — if ESPN changes a
-field name or nests data differently, it will fail at JSON decode time with a
-potentially unclear error.
+### ~~ESPN API fragility~~ (resolved 2026-02-13)
+Added HTTP status code validation and 5xx retry in `makeRequest`, wrapped JSON
+decode errors with endpoint context, added `validate()` methods on all three
+response types (`GameScheduleESPN`, `GameInfoESPN`, `TeamInfoESPN`), and guarded
+remaining unprotected slice index accesses in `espn.go`.
 
 ### Updater CLI flag surface area
 `cmd/updater/main.go` has grown to 8 boolean flags and a mix of scheduling and

--- a/internal/espn/espn.go
+++ b/internal/espn/espn.go
@@ -95,6 +95,11 @@ func HasPostseasonStarted(year int64, startTime time.Time) (bool, error) {
 		return false, err
 	}
 
+	if len(res.Content.Calendar) < 2 {
+		return false, fmt.Errorf("schedule response has %d calendar entries, need at least 2 for postseason",
+			len(res.Content.Calendar))
+	}
+
 	postSeasonStart, _ := time.Parse("2006-01-02T15:04Z",
 		res.Content.Calendar[1].StartDate)
 	return postSeasonStart.Before(startTime), nil
@@ -234,6 +239,9 @@ func extractTeamConfs(games *GameScheduleESPN) map[int64]int64 {
 
 	for _, day := range games.Content.Schedule {
 		for _, event := range day.Games {
+			if len(event.Competitions) == 0 {
+				continue
+			}
 			for _, team := range event.Competitions[0].Competitors {
 				teamConfs[team.Team.ID] = team.Team.ConferenceID
 			}

--- a/internal/espn/game_info_espn.go
+++ b/internal/espn/game_info_espn.go
@@ -1,5 +1,7 @@
 package espn
 
+import "errors"
+
 //nolint:gochecknoglobals // overridden in tests
 var gameStatsURL = "https://cdn.espn.com/core/college-football/playbyplay" +
 	"?gameId=%d&xhr=1&render=false&userab=18"
@@ -81,4 +83,17 @@ type Athlete struct {
 	ID        int64  `json:"id,string"`
 	FirstName string `json:"firstName"`
 	LastName  string `json:"lastName"`
+}
+
+func (r GameInfoESPN) validate() error {
+	if r.GamePackage.Header.ID == 0 {
+		return errors.New("game info response has zero header ID")
+	}
+	if len(r.GamePackage.Header.Competitions) == 0 {
+		return errors.New("game info response missing competitions")
+	}
+	if len(r.GamePackage.Header.Competitions[0].Competitors) < 2 {
+		return errors.New("game info response has fewer than 2 competitors")
+	}
+	return nil
 }

--- a/internal/espn/game_schedule_espn.go
+++ b/internal/espn/game_schedule_espn.go
@@ -1,5 +1,7 @@
 package espn
 
+import "errors"
+
 //nolint:gochecknoglobals // overridden in tests
 var weekURL = "https://cdn.espn.com/core/college-football/schedule?xhr=1&render=false&userab=18"
 
@@ -81,4 +83,14 @@ type Conference struct {
 	Logo          string   `json:"logo"`
 	ParentGroupID int64    `json:"parentGroupId,string"`
 	ShortName     string   `json:"shortName"`
+}
+
+func (r GameScheduleESPN) validate() error {
+	if len(r.Content.Calendar) == 0 {
+		return errors.New("schedule response missing calendar entries")
+	}
+	if len(r.Content.Calendar[0].Weeks) == 0 {
+		return errors.New("schedule response has empty weeks in first calendar entry")
+	}
+	return nil
 }

--- a/internal/espn/team_info.go
+++ b/internal/espn/team_info.go
@@ -1,5 +1,7 @@
 package espn
 
+import "errors"
+
 //nolint:gochecknoglobals // overridden in tests
 var teamInfoURL = "https://site.api.espn.com/apis/site/v2/sports/football/college-football/teams?limit=1000"
 
@@ -62,4 +64,17 @@ type Logo struct {
 	Href   string   `json:"href"`
 	Rel    []string `json:"rel"`
 	Width  int64    `json:"width"`
+}
+
+func (r TeamInfoESPN) validate() error {
+	if len(r.Sports) == 0 {
+		return errors.New("team info response missing sports")
+	}
+	if len(r.Sports[0].Leagues) == 0 {
+		return errors.New("team info response missing leagues")
+	}
+	if len(r.Sports[0].Leagues[0].Teams) == 0 {
+		return errors.New("team info response missing teams")
+	}
+	return nil
 }

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -36,6 +36,9 @@ func setupGameTestServer(t *testing.T) *httptest.Server {
 						},
 					},
 				},
+				Calendar: []espn.Calendar{
+					{Weeks: []espn.Week{{Num: 1}}},
+				},
 			},
 		}); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -1,7 +1,6 @@
 package team
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/robby-barton/stats-go/internal/espn"
@@ -32,15 +31,6 @@ func GetTeamInfo() ([]ParsedTeamInfo, error) {
 	res, err := espn.GetTeamInfo()
 	if err != nil {
 		return nil, err
-	}
-
-	//nolint:gocritic // need to check nesting parse
-	if len(res.Sports) == 0 {
-		return nil, errors.New("no sport")
-	} else if len(res.Sports[0].Leagues) == 0 {
-		return nil, errors.New("no league")
-	} else if len(res.Sports[0].Leagues[0].Teams) == 0 {
-		return nil, errors.New("no teams")
 	}
 
 	teams := res.Sports[0].Leagues[0].Teams


### PR DESCRIPTION
## Summary
- Add HTTP status code validation in `makeRequest` with 5xx retry, and wrap JSON decode errors with endpoint context
- Add `validate()` methods on `GameScheduleESPN`, `GameInfoESPN`, and `TeamInfoESPN` to catch missing/malformed structural data early
- Guard unprotected slice index accesses in `HasPostseasonStarted` (`Calendar[1]`) and `extractTeamConfs` (`Competitions[0]`)
- Remove redundant nesting checks from `team/team.go` (now handled by `validate()`)

## Test plan
- [x] `go test ./internal/... ./cmd/...` — all pass
- [x] `golangci-lint run` — 0 issues
- [x] New tests cover: non-2xx responses, malformed JSON, empty responses, and all three `validate()` methods