### PR TITLE
Rewrite README and fix Dockerfile entrypoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,14 +63,15 @@ Key patterns:
 
 Any change that alters architecture, package dependencies, public interfaces,
 ESPN API usage, conventions, or design rationale **must** include corresponding
-updates to the relevant docs (`CLAUDE.md`, `ARCHITECTURE.md`, or files in
-`docs/`). Documentation that contradicts the code is worse than no documentation
+updates to the relevant docs (`README.md`, `CLAUDE.md`, `ARCHITECTURE.md`, or
+files in `docs/`). Documentation that contradicts the code is worse than no documentation
 at all — it actively misleads future work.
 
-When in doubt, update the docs. When adding a new package or changing how an
-existing one works, update `ARCHITECTURE.md`. When making a deliberate tradeoff,
-record it in `docs/design-decisions.md`. When discovering or resolving tech
-debt, update `docs/tech-debt.md`.
+When in doubt, update the docs. `README.md` is written for a human audience —
+keep it clear, practical, and free of agent-facing jargon. When adding a new
+package or changing how an existing one works, update `ARCHITECTURE.md`. When
+making a deliberate tradeoff, record it in `docs/design-decisions.md`. When
+discovering or resolving tech debt, update `docs/tech-debt.md`.
 
 ## Deeper Documentation
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN apk add --no-cache tzdata
 ENV TZ=America/New_York
 
 COPY --from=builder /app/updater .
-ENTRYPOINT ["/updater", "-schedule"]
+ENTRYPOINT ["/updater", "schedule"]

--- a/README.md
+++ b/README.md
@@ -1,46 +1,135 @@
 # College Football Computer Ranking
-A set of Go services for ranking college football teams.
 
-## Development
+A Go application that pulls game data from the ESPN API, computes SRS/SOS
+composite rankings for college football teams, and exports results to
+DigitalOcean Spaces.
+
+## Overview
+
+The system consists of two CLI tools:
+
+- **Ranker** — calculates and prints rankings for a given year/week
+- **Updater** — scheduled service that fetches games, updates the database,
+  computes rankings, and exports JSON to a CDN
+
+Rankings use a composite algorithm based on Simple Rating System (SRS) and
+Strength of Schedule (SOS), supporting both FBS and FCS divisions.
+
+## Getting Started
+
+### Prerequisites
+
+- Go 1.26+
+- golangci-lint (for linting)
+- PostgreSQL (optional — SQLite is used automatically when no PG env vars are set)
+
 ### Setup
-Run `make modules` to sync modules with `go.mod`.
 
-### Environment
-Copy `.env-sample` to `.env` and set the variables to the desired values.
+```sh
+cp .env-sample .env   # configure database and DigitalOcean credentials
+make modules          # sync Go module dependencies
+```
 
-The services are currently set up to only connect to PostgreSQL databases.
+### Environment Variables
 
-## Services
-### Running and Building
-Each of the services can be run locally using `make {ranker,updater}`.
+Set in `.env` (see `.env-sample` for the full list):
 
-When running the services locally you can pass command line arguments by appending
-`OPTS="..."` to the make call: `make ranker OPTS="-t 25"`.
+| Variable | Description |
+|----------|-------------|
+| `PG_HOST`, `PG_PORT`, `PG_USER`, `PG_PASSWORD`, `PG_DBNAME`, `PG_SSLMODE` | PostgreSQL connection (omit all to use SQLite) |
+
+## Usage
 
 ### Ranker
-Ranker will generate a ranking for the year/week requested and print the results.
 
-#### Options
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `-y YEAR` | `int` | most recent | The year to rank |
-| `-w WEEK` | `int` | most recent | The week of the season to rank |
-| `-f` | `bool` | `false` | Rank the FCS |
-| `-t N` | `int` | all | Print the top N teams |
-| `-r` | `bool` | `false` | Print the SRS rating instead of full ranking |
+Generate and print a ranking:
+
+```sh
+make ranker                      # current season, all teams
+make ranker OPTS="-t 25"         # top 25
+make ranker OPTS="-y 2024 -w 12" # specific year and week
+make ranker OPTS="-f"            # rank FCS instead of FBS
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `-y` | int | most recent | Year to rank |
+| `-w` | int | most recent | Week of the season |
+| `-f` | bool | false | Rank FCS instead of FBS |
+| `-t` | int | all | Print only the top N teams |
+| `-r` | bool | false | Print SRS ratings instead of full ranking |
 
 ### Updater
-Updater will update the database with game information and new rankings.
 
-Updater can run on-demand updates or run as a service and update on a schedule.
+Run one-off operations or start the scheduled service:
 
-#### Options
-| Option | Default | Description |
-| --- | --- | --- |
-| `-s` | `true` | Run as scheduler |
-| `-g` | `false` | Update games now. Will run once and exit. |
-| `-r` | `false` | Update current ranking now. Will run once and exit. |
-| `-a` | `false` | Update all games or rankings. Use with `-g` or `-r`. |
+```sh
+make updater OPTS="schedule"              # run as scheduled service
+make updater OPTS="games"                 # update current week's games
+make updater OPTS="games --all"           # update all games for current year
+make updater OPTS="games --single 12345"  # force-update a single game by ID
+make updater OPTS="ranking"               # update current season rankings
+make updater OPTS="ranking --all"         # update all rankings
+make updater OPTS="teams"                 # update team info
+make updater OPTS="season"               # update season info
+make updater OPTS="json"                  # rewrite current season JSON
+make updater OPTS="json --all"            # rewrite all JSON
+```
 
-#### Scheduler
-The updater can run in scheduled mode which will wake up and search for new games finished every 5 minutes. If a new game is found it will add the game info to the database and update the current rankings.
+| Command | Flags | Description |
+|---------|-------|-------------|
+| `schedule` | | Run as a scheduled service (polls every 5 min Aug-Jan) |
+| `games` | `--all`, `--single <id>` | Update games (current week by default) |
+| `ranking` | `--all` | Update rankings (current season by default) |
+| `teams` | | Update team info from ESPN |
+| `season` | | Update season info |
+| `json` | `--all` | Rewrite JSON output (current season by default) |
+
+## Development
+
+```sh
+make ranker           # build and run ranker
+make updater          # build and run updater
+go test ./...         # run all tests
+make lint             # run golangci-lint
+make format           # go fmt
+```
+
+## Project Structure
+
+```
+cmd/
+  ranker/             CLI: calculate and print rankings
+  updater/            CLI: fetch games, update DB, export JSON
+  migrate/            CLI: one-time migration from PostgreSQL to SQLite
+internal/
+  config/             Environment-based configuration (godotenv)
+  database/           GORM models and DB initialization (Postgres + SQLite)
+  espn/               ESPN API client (game schedules, stats, team info)
+  game/               Game data parsing and stat extraction
+  logger/             Structured logging (zap)
+  ranking/            Ranking algorithm (SRS, SOS, composite scoring)
+  team/               Team info parsing from ESPN
+  updater/            Orchestration of DB updates and JSON export
+  writer/             Output interface (DigitalOcean Spaces or local files)
+```
+
+## Deployment
+
+The project uses a Docker multi-stage build to produce a minimal Alpine image
+running the updater in scheduled mode.
+
+```sh
+make local-deploy     # build and run via docker compose
+```
+
+In production, the container runs `updater schedule`, which polls for completed
+games every 5 minutes during the season (August through January).
+
+## CI/CD
+
+GitHub Actions runs two workflows:
+
+- **Pull Requests** — lint and test on PRs targeting master
+- **Deploy** — lint, test, build Docker image, and push to DigitalOcean
+  Container Registry on merge to master


### PR DESCRIPTION
## Summary

- Rewrite `README.md` with complete sections: overview, getting started, usage (flag/subcommand tables with examples), development, project structure, deployment, and CI/CD
- Fix stale claim that only PostgreSQL is supported — documents SQLite as the default when no PG env vars are set
- Fix Dockerfile `ENTRYPOINT` from old `-schedule` flag to cobra `schedule` subcommand
- Update `CLAUDE.md` golden rule to include `README.md` in the docs list and note it's written for a human audience

## Test plan

- [x] `golangci-lint` passes
- [x] `go test ./cmd/... ./internal/...` passes
- [x] `go build ./cmd/updater` compiles
- [ ] Review README content for accuracy and readability