### PR TITLE
Migrate updater CLI from flags to cobra subcommands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ data
 *.db
 
 # binaries
-ranker
-updater
-migrate
+/ranker
+/updater
+/migrate

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -126,6 +126,6 @@ All models use composite primary keys for multi-dimensional lookups
 ## Deployment
 
 - **Docker:** Multi-stage build (`golang:1.26-alpine` → `alpine:latest`)
-- **Production:** `updater -schedule` running in a container alongside PostgreSQL
+- **Production:** `updater schedule` running in a container alongside PostgreSQL
 - **CI/CD:** GitHub Actions — lint and test on PR, build+push on merge to master
 - **Output:** JSON files served from DigitalOcean Spaces CDN

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ updater:
 	@go run ./cmd/updater ${OPTS}
 
 update-all-rankings:
-	@go run ./cmd/updater -ranking -all
+	@go run ./cmd/updater ranking --all
 
 ranker:
 	@go run ./cmd/ranker ${OPTS}

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"context"
-	"flag"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
 	"github.com/go-co-op/gocron/v2"
+	"github.com/spf13/cobra"
 
 	"github.com/robby-barton/stats-go/internal/config"
 	"github.com/robby-barton/stats-go/internal/database"
@@ -18,21 +18,8 @@ import (
 )
 
 func main() {
-	logger := logger.NewLogger().Sugar()
-	defer logger.Sync()
-
-	var scheduled, games, rank, all, team, season, json bool
-	var singleGame int64
-
-	flag.BoolVar(&scheduled, "schedule", false, "run scheduler")
-	flag.BoolVar(&games, "games", false, "one-time game update")
-	flag.Int64Var(&singleGame, "single", 0, "force update one game")
-	flag.BoolVar(&rank, "ranking", false, "one-time ranking update")
-	flag.BoolVar(&all, "all", false, "update all rankings or games")
-	flag.BoolVar(&team, "teams", false, "update team info")
-	flag.BoolVar(&season, "season", false, "update season info")
-	flag.BoolVar(&json, "json", false, "rewrite json")
-	flag.Parse()
+	log := logger.NewLogger().Sugar()
+	defer log.Sync()
 
 	cfg := config.SetupConfig()
 
@@ -49,192 +36,249 @@ func main() {
 	}
 	u := updater.Updater{
 		DB:     db,
-		Logger: logger,
+		Logger: log,
 		Writer: doWriter,
 	}
 
-	if scheduled {
-		s, err := gocron.NewScheduler(gocron.WithLocation(time.Local))
-		if err != nil {
-			panic(err)
-		}
+	rootCmd := &cobra.Command{
+		Use:   "updater",
+		Short: "College football data updater",
+	}
+	rootCmd.SilenceUsage = true
 
-		update := make(chan bool, 1)
-		stop := make(chan bool, 1)
-		go func() {
-			for {
-				select {
-				case <-update:
-					func() {
-						defer func() {
-							if r := recover(); r != nil {
-								logger.Errorf("panic caught: %s", r)
+	scheduleCmd := &cobra.Command{
+		Use:   "schedule",
+		Short: "Run the scheduled updater",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			s, err := gocron.NewScheduler(gocron.WithLocation(time.Local))
+			if err != nil {
+				panic(err)
+			}
+
+			update := make(chan bool, 1)
+			stop := make(chan bool, 1)
+			go func() {
+				for {
+					select {
+					case <-update:
+						func() {
+							defer func() {
+								if r := recover(); r != nil {
+									log.Errorf("panic caught: %s", r)
+								}
+							}()
+
+							if err := u.UpdateRecentRankings(); err != nil {
+								log.Error(err)
+								return
+							}
+							log.Info("rankings updated")
+
+							if !cfg.Local {
+								if err := u.UpdateRecentJSON(); err != nil {
+									log.Error(err)
+								}
 							}
 						}()
+					case <-stop:
+						return
+					}
+				}
+			}()
 
-						if err := u.UpdateRecentRankings(); err != nil {
-							logger.Error(err)
-							return
-						}
-						logger.Info("rankings updated")
+			// Update completed games
+			// every 5 minutes from August through January
+			_, err = s.NewJob(gocron.CronJob("*/5 * * 1,8-12 *", false), gocron.NewTask(func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Errorf("panic caught: %s", r)
+					}
+				}()
 
-						if !cfg.Local {
-							if err := u.UpdateRecentJSON(); err != nil {
-								logger.Error(err)
-							}
-						}
-					}()
-				case <-stop:
+				var addedGames []int64
+				addedGames, err = u.UpdateCurrentWeek()
+
+				log.Infof("Added %d games: %v", len(addedGames), addedGames)
+				if err != nil {
+					log.Error(err)
+				} else if len(addedGames) > 0 {
+					update <- true
+				}
+			}))
+			if err != nil {
+				panic(err)
+			}
+
+			// Update team info
+			// 5 am Sunday from August through January
+			_, err = s.NewJob(gocron.CronJob("0 5 * 1,8-12 0", false), gocron.NewTask(func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Errorf("panic caught: %s", r)
+					}
+				}()
+
+				var addedTeams int
+				addedTeams, err = u.UpdateTeamInfo()
+				if err != nil {
+					log.Error(err)
 					return
 				}
-			}
-		}()
 
-		// Update completed games
-		// every 5 minutes from August through January
-		_, err = s.NewJob(gocron.CronJob("*/5 * * 1,8-12 *", false), gocron.NewTask(func() {
-			defer func() {
-				if r := recover(); r != nil {
-					logger.Errorf("panic caught: %s", r)
+				log.Infof("Updated %d teams", addedTeams)
+				if !cfg.Local {
+					if err := u.UpdateTeamsJSON(nil); err != nil {
+						log.Error(err)
+					}
+					if err := u.Writer.PurgeCache(context.Background()); err != nil {
+						log.Error(err)
+					}
 				}
-			}()
+			}))
+			if err != nil {
+				panic(err)
+			}
+
+			// Add new season
+			// 6 am on August 10th
+			_, err = s.NewJob(gocron.CronJob("0 6 10 8 *", false), gocron.NewTask(func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Errorf("panic caught: %s", r)
+					}
+				}()
+
+				var addedSeasons int
+				addedSeasons, err = u.UpdateTeamSeasons(false)
+
+				log.Infof("Added %d seasons", addedSeasons)
+				if err != nil {
+					log.Error(err)
+				} else if addedSeasons > 0 {
+					update <- true
+				}
+			}))
+			if err != nil {
+				panic(err)
+			}
+
+			s.Start()
+
+			end := make(chan os.Signal, 1)
+			signal.Notify(end, syscall.SIGINT, syscall.SIGTERM)
+
+			<-end
+			if err := s.Shutdown(); err != nil {
+				log.Error(err)
+			}
+			stop <- true
+
+			return nil
+		},
+	}
+
+	var gamesAll bool
+	var gamesSingle int64
+	gamesCmd := &cobra.Command{
+		Use:   "games",
+		Short: "One-time game update",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if gamesSingle > 0 {
+				if err := u.UpdateSingleGame(gamesSingle); err != nil {
+					log.Error(err)
+				} else {
+					log.Infof("Game %d updated", gamesSingle)
+				}
+				return nil
+			}
 
 			var addedGames []int64
-			addedGames, err = u.UpdateCurrentWeek()
-
-			logger.Infof("Added %d games: %v", len(addedGames), addedGames)
-			if err != nil {
-				logger.Error(err)
-			} else if len(addedGames) > 0 {
-				update <- true
-			}
-		}))
-		if err != nil {
-			panic(err)
-		}
-
-		// Update team info
-		// 5 am Sunday from August through January
-		_, err = s.NewJob(gocron.CronJob("0 5 * 1,8-12 0", false), gocron.NewTask(func() {
-			defer func() {
-				if r := recover(); r != nil {
-					logger.Errorf("panic caught: %s", r)
-				}
-			}()
-
-			var addedTeams int
-			addedTeams, err = u.UpdateTeamInfo()
-			if err != nil {
-				logger.Error(err)
-				return
-			}
-
-			logger.Infof("Updated %d teams", addedTeams)
-			if !cfg.Local {
-				if err := u.UpdateTeamsJSON(nil); err != nil {
-					logger.Error(err)
-				}
-				if err := u.Writer.PurgeCache(context.Background()); err != nil {
-					logger.Error(err)
-				}
-			}
-		}))
-		if err != nil {
-			panic(err)
-		}
-
-		// Add new season
-		// 6 am on August 10th
-		_, err = s.NewJob(gocron.CronJob("0 6 10 8 *", false), gocron.NewTask(func() {
-			defer func() {
-				if r := recover(); r != nil {
-					logger.Errorf("panic caught: %s", r)
-				}
-			}()
-
-			var addedSeasons int
-			addedSeasons, err = u.UpdateTeamSeasons(false)
-
-			logger.Infof("Added %d seasons", addedSeasons)
-			if err != nil {
-				logger.Error(err)
-			} else if addedSeasons > 0 {
-				update <- true
-			}
-		}))
-		if err != nil {
-			panic(err)
-		}
-
-		s.Start()
-
-		end := make(chan os.Signal, 1)
-		signal.Notify(end, syscall.SIGINT, syscall.SIGTERM)
-
-		<-end
-		if err := s.Shutdown(); err != nil {
-			logger.Error(err)
-		}
-		stop <- true
-	} else {
-		if games {
-			var addedGames []int64
-			if all {
+			var err error
+			if gamesAll {
 				year, _, _ := time.Now().Date()
 				addedGames, err = u.UpdateGamesForYear(int64(year))
 			} else {
 				addedGames, err = u.UpdateCurrentWeek()
 			}
 			if err != nil {
-				logger.Error(err)
+				log.Error(err)
 			} else {
-				logger.Infof("Added %d games: %v", len(addedGames), addedGames)
+				log.Infof("Added %d games: %v", len(addedGames), addedGames)
 			}
-		}
-		if singleGame > 0 {
-			if err := u.UpdateSingleGame(singleGame); err != nil {
-				logger.Error(err)
-			} else {
-				logger.Infof("Game %d updated", singleGame)
-			}
-		}
-		if rank {
-			if all {
+			return nil
+		},
+	}
+	gamesCmd.Flags().BoolVar(&gamesAll, "all", false, "update all games for the current year")
+	gamesCmd.Flags().Int64Var(&gamesSingle, "single", 0, "force update one game by ID")
+	gamesCmd.MarkFlagsMutuallyExclusive("all", "single")
+
+	var rankingAll bool
+	rankingCmd := &cobra.Command{
+		Use:   "ranking",
+		Short: "One-time ranking update",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			var err error
+			if rankingAll {
 				err = u.UpdateAllRankings()
 			} else {
 				err = u.UpdateRecentRankings()
 			}
 			if err != nil {
-				logger.Error(err)
+				log.Error(err)
 			}
-		}
-		if team {
-			var addedTeams int
-			addedTeams, err = u.UpdateTeamInfo()
+			return nil
+		},
+	}
+	rankingCmd.Flags().BoolVar(&rankingAll, "all", false, "update all rankings")
+
+	teamsCmd := &cobra.Command{
+		Use:   "teams",
+		Short: "Update team info",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			addedTeams, err := u.UpdateTeamInfo()
 			if err != nil {
-				logger.Error(err)
+				log.Error(err)
 			} else {
-				logger.Infof("Updated %d teams", addedTeams)
+				log.Infof("Updated %d teams", addedTeams)
 			}
-		}
-		if season {
-			var addedSeasons int
-			addedSeasons, err = u.UpdateTeamSeasons(true)
+			return nil
+		},
+	}
+
+	seasonCmd := &cobra.Command{
+		Use:   "season",
+		Short: "Update season info",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			addedSeasons, err := u.UpdateTeamSeasons(true)
 			if err != nil {
-				logger.Error(err)
+				log.Error(err)
 			} else {
-				logger.Infof("Added %d seasons", addedSeasons)
+				log.Infof("Added %d seasons", addedSeasons)
 			}
-		}
-		if json {
-			if all {
+			return nil
+		},
+	}
+
+	var jsonAll bool
+	jsonCmd := &cobra.Command{
+		Use:   "json",
+		Short: "Rewrite JSON output",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			var err error
+			if jsonAll {
 				err = u.UpdateAllJSON()
 			} else {
 				err = u.UpdateRecentJSON()
 			}
 			if err != nil {
-				logger.Error(err)
+				log.Error(err)
 			}
-		}
+			return nil
+		},
 	}
+	jsonCmd.Flags().BoolVar(&jsonAll, "all", false, "rewrite all JSON")
+
+	rootCmd.AddCommand(scheduleCmd, gamesCmd, rankingCmd, teamsCmd, seasonCmd, jsonCmd)
+
+	rootCmd.Execute() //nolint:errcheck // cobra prints errors; exit code unused
 }

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -13,20 +13,18 @@ decode errors with endpoint context, added `validate()` methods on all three
 response types (`GameScheduleESPN`, `GameInfoESPN`, `TeamInfoESPN`), and guarded
 remaining unprotected slice index accesses in `espn.go`.
 
-### Updater CLI flag surface area
-`cmd/updater/main.go` has grown to 8 boolean flags and a mix of scheduling and
-one-shot modes in a single `main()`. This could be clearer with subcommands
-(e.g., `updater schedule`, `updater games --all`).
-
 ### Hard-coded rate limiting
 The 200ms sleep in `game/` and 1s retry backoff in `espn/request.go` are
 hard-coded. These could be configurable or use exponential backoff.
 
-### Home field advantage constant unused in final ranking
-`rating.go` defines `hfa = 3` (home field advantage) but it is not currently
-used in any calculation. Unclear if this is intentional or vestigial.
-
 ## Resolved
+
+### Updater CLI flag surface area (resolved 2026-02-13)
+Replaced 8 flat boolean flags with cobra subcommands (`schedule`, `games`,
+`ranking`, `teams`, `season`, `json`). Each subcommand owns its own flags.
+
+### Home field advantage constant unused (resolved 2026-02-13)
+Removed the dead `hfa` constant from `internal/ranking/rating.go`.
 
 ### Dependency versions are dated (resolved 2026-02-13)
 Upgraded Go 1.21 → 1.26, aws-sdk-go v1 → v2, gocron v1 → v2, GORM

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-co-op/gocron/v2 v2.19.1
 	github.com/jedib0t/go-pretty/v6 v6.4.8
 	github.com/joho/godotenv v1.4.0
+	github.com/spf13/cobra v1.10.2
 	go.uber.org/zap v1.27.1
 	gonum.org/v1/gonum v0.12.0
 	gorm.io/driver/postgres v1.6.0
@@ -22,6 +23,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.6.0 // indirect
@@ -33,6 +35,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/net v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,7 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -122,6 +123,8 @@ github.com/hashicorp/go-retryablehttp v0.7.4/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
@@ -159,6 +162,11 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -183,6 +191,7 @@ go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.1 h1:08RqriUEv8+ArZRYSTXy1LeBScaMpVSTBhCeaZYfMYc=
 go.uber.org/zap v1.27.1/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/internal/ranking/rating.go
+++ b/internal/ranking/rating.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	hfa           int64 = 3
 	requiredGames int   = 12
 	yearsBack     int64 = 2
 	runs          int   = 10000


### PR DESCRIPTION
## Summary
- Replace 8 flat boolean flags in `cmd/updater/main.go` with cobra subcommands (`schedule`, `games`, `ranking`, `teams`, `season`, `json`), each owning its own flags with mutual exclusivity where appropriate
- Remove unused `hfa` constant from `internal/ranking/rating.go`
- Update `Makefile`, `ARCHITECTURE.md`, and `docs/tech-debt.md` to reflect the new CLI surface

## Test plan
- [ ] `go build ./cmd/updater` compiles successfully
- [ ] `go run ./cmd/updater --help` shows subcommand list
- [ ] `go run ./cmd/updater games --help` shows `--all` and `--single` flags
- [ ] `go test ./...` passes
- [ ] `golangci-lint run --config=.golangci.yml ./cmd/... ./internal/...` passes