### PR TITLE
Replace hard-coded rate limiting with exponential backoff

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -89,6 +89,7 @@ type Updater struct {
     DB     *gorm.DB
     Logger *zap.SugaredLogger
     Writer writer.Writer
+    ESPN   *espn.Client
 }
 ```
 
@@ -111,8 +112,11 @@ All computation happens in-memory after initial DB queries.
 
 ### ESPN Client
 
-Stateless HTTP client. All functions are package-level (no struct). URLs are
-package-level vars so tests can override them with a mock HTTP server.
+HTTP client backed by the `espn.Client` struct, which holds retry and
+rate-limit configuration (`MaxRetries`, `InitialBackoff`, `RequestTimeout`,
+`RateLimit`). Retries use exponential backoff capped at 30s. All ESPN
+functions are methods on `*Client`. URLs are package-level vars so tests can
+override them with a mock HTTP server.
 
 ## Database
 

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/robby-barton/stats-go/internal/config"
 	"github.com/robby-barton/stats-go/internal/database"
+	"github.com/robby-barton/stats-go/internal/espn"
 	"github.com/robby-barton/stats-go/internal/logger"
 	"github.com/robby-barton/stats-go/internal/updater"
 	"github.com/robby-barton/stats-go/internal/writer"
@@ -34,10 +35,12 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	espnClient := espn.NewClient()
 	u := updater.Updater{
 		DB:     db,
 		Logger: log,
 		Writer: doWriter,
+		ESPN:   espnClient,
 	}
 
 	rootCmd := &cobra.Command{

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -13,9 +13,10 @@ decode errors with endpoint context, added `validate()` methods on all three
 response types (`GameScheduleESPN`, `GameInfoESPN`, `TeamInfoESPN`), and guarded
 remaining unprotected slice index accesses in `espn.go`.
 
-### Hard-coded rate limiting
-The 200ms sleep in `game/` and 1s retry backoff in `espn/request.go` are
-hard-coded. These could be configurable or use exponential backoff.
+### ~~Hard-coded rate limiting~~ (resolved 2026-02-13)
+Introduced `espn.Client` struct with configurable `MaxRetries`,
+`InitialBackoff`, `RequestTimeout`, and `RateLimit` fields. Retry logic now
+uses exponential backoff (`initialBackoff * 2^attempt`, capped at 30s).
 
 ## Resolved
 

--- a/internal/espn/espn.go
+++ b/internal/espn/espn.go
@@ -21,13 +21,13 @@ const (
 	Postseason SeasonType = 3
 )
 
-func GetCurrentWeekGames(group Group) ([]Game, error) {
+func (c *Client) GetCurrentWeekGames(group Group) ([]Game, error) {
 	var games []Game
 
 	url := weekURL + fmt.Sprintf("&group=%d", group)
 
 	var res GameScheduleESPN
-	err := makeRequest(url, &res)
+	err := c.makeRequest(url, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -43,12 +43,12 @@ func GetCurrentWeekGames(group Group) ([]Game, error) {
 	return games, nil
 }
 
-func GetGamesByWeek(year int64, week int64, group Group, seasonType SeasonType) (*GameScheduleESPN, error) {
+func (c *Client) GetGamesByWeek(year int64, week int64, group Group, seasonType SeasonType) (*GameScheduleESPN, error) {
 	url := weekURL +
 		fmt.Sprintf("&year=%d&week=%d&group=%d&seasonType=%d", year, week, group, seasonType)
 
 	var res GameScheduleESPN
-	err := makeRequest(url, &res)
+	err := c.makeRequest(url, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -56,8 +56,8 @@ func GetGamesByWeek(year int64, week int64, group Group, seasonType SeasonType) 
 	return &res, nil
 }
 
-func GetCompletedGamesByWeek(year int64, week int64, group Group, seasonType SeasonType) ([]Game, error) {
-	res, err := GetGamesByWeek(year, week, group, seasonType)
+func (c *Client) GetCompletedGamesByWeek(year int64, week int64, group Group, seasonType SeasonType) ([]Game, error) {
+	res, err := c.GetGamesByWeek(year, week, group, seasonType)
 	if err != nil {
 		return nil, err
 	}
@@ -74,11 +74,11 @@ func GetCompletedGamesByWeek(year int64, week int64, group Group, seasonType Sea
 	return games, nil
 }
 
-func GetWeeksInSeason(year int64) (int64, error) {
+func (c *Client) GetWeeksInSeason(year int64) (int64, error) {
 	url := weekURL + fmt.Sprintf("&year=%d", year)
 
 	var res GameScheduleESPN
-	err := makeRequest(url, &res)
+	err := c.makeRequest(url, &res)
 	if err != nil {
 		return 0, err
 	}
@@ -86,11 +86,11 @@ func GetWeeksInSeason(year int64) (int64, error) {
 	return int64(len(res.Content.Calendar[0].Weeks)), nil
 }
 
-func HasPostseasonStarted(year int64, startTime time.Time) (bool, error) {
+func (c *Client) HasPostseasonStarted(year int64, startTime time.Time) (bool, error) {
 	url := weekURL + fmt.Sprintf("&year=%d", year)
 
 	var res GameScheduleESPN
-	err := makeRequest(url, &res)
+	err := c.makeRequest(url, &res)
 	if err != nil {
 		return false, err
 	}
@@ -105,16 +105,16 @@ func HasPostseasonStarted(year int64, startTime time.Time) (bool, error) {
 	return postSeasonStart.Before(startTime), nil
 }
 
-func GetGamesBySeason(year int64, group Group) ([]Game, error) {
+func (c *Client) GetGamesBySeason(year int64, group Group) ([]Game, error) {
 	var gameIDs []Game
 
-	numWeeks, err := GetWeeksInSeason(year)
+	numWeeks, err := c.GetWeeksInSeason(year)
 	if err != nil {
 		return nil, err
 	}
 
 	for i := int64(1); i < numWeeks; i++ {
-		games, err := GetCompletedGamesByWeek(year, i, group, Regular)
+		games, err := c.GetCompletedGamesByWeek(year, i, group, Regular)
 		if err != nil {
 			return nil, err
 		}
@@ -122,7 +122,7 @@ func GetGamesBySeason(year int64, group Group) ([]Game, error) {
 		gameIDs = append(gameIDs, games...)
 	}
 
-	games, err := GetCompletedGamesByWeek(year, int64(1), group, Postseason)
+	games, err := c.GetCompletedGamesByWeek(year, int64(1), group, Postseason)
 	if err != nil {
 		return nil, err
 	}
@@ -132,11 +132,11 @@ func GetGamesBySeason(year int64, group Group) ([]Game, error) {
 	return gameIDs, nil
 }
 
-func GetGameStats(gameID int64) (*GameInfoESPN, error) {
+func (c *Client) GetGameStats(gameID int64) (*GameInfoESPN, error) {
 	url := fmt.Sprintf(gameStatsURL, gameID)
 
 	var res GameInfoESPN
-	err := makeRequest(url, &res)
+	err := c.makeRequest(url, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -144,9 +144,9 @@ func GetGameStats(gameID int64) (*GameInfoESPN, error) {
 	return &res, nil
 }
 
-func GetTeamInfo() (*TeamInfoESPN, error) {
+func (c *Client) GetTeamInfo() (*TeamInfoESPN, error) {
 	var res TeamInfoESPN
-	err := makeRequest(teamInfoURL, &res)
+	err := c.makeRequest(teamInfoURL, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -154,9 +154,9 @@ func GetTeamInfo() (*TeamInfoESPN, error) {
 	return &res, nil
 }
 
-func DefaultSeason() (int64, error) {
+func (c *Client) DefaultSeason() (int64, error) {
 	var res GameScheduleESPN
-	err := makeRequest(weekURL, &res)
+	err := c.makeRequest(weekURL, &res)
 	if err != nil {
 		return 0, err
 	}
@@ -164,9 +164,9 @@ func DefaultSeason() (int64, error) {
 	return res.Content.Defaults.Year, nil
 }
 
-func ConferenceMap() (map[Group]interface{}, error) {
+func (c *Client) ConferenceMap() (map[Group]interface{}, error) {
 	var res GameScheduleESPN
-	err := makeRequest(weekURL, &res)
+	err := c.makeRequest(weekURL, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -207,24 +207,24 @@ func ConferenceMap() (map[Group]interface{}, error) {
 	}, nil
 }
 
-func TeamConferencesByYear(year int64) (map[int64]int64, error) {
+func (c *Client) TeamConferencesByYear(year int64) (map[int64]int64, error) {
 	teamConfs := map[int64]int64{}
 
-	numWeeks, err := GetWeeksInSeason(year)
+	numWeeks, err := c.GetWeeksInSeason(year)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, group := range []Group{FBS, FCS} {
 		for i := int64(1); i < numWeeks; i++ {
-			games, err := GetGamesByWeek(year, i, group, Regular)
+			games, err := c.GetGamesByWeek(year, i, group, Regular)
 			if err != nil {
 				return nil, err
 			}
 			maps.Copy(teamConfs, extractTeamConfs(games))
 		}
 
-		games, err := GetGamesByWeek(year, int64(1), group, Postseason)
+		games, err := c.GetGamesByWeek(year, int64(1), group, Postseason)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/espn/espn_test.go
+++ b/internal/espn/espn_test.go
@@ -53,11 +53,21 @@ func overrideURLs(t *testing.T, serverURL string) {
 	t.Cleanup(restore)
 }
 
+func newTestClient() *Client {
+	return &Client{
+		MaxRetries:     2,
+		InitialBackoff: 10 * time.Millisecond,
+		RequestTimeout: 1 * time.Second,
+		RateLimit:      0,
+	}
+}
+
 func TestGetCurrentWeekGames(t *testing.T) {
 	ts := setupTestServer(t)
 	overrideURLs(t, ts.URL)
+	client := newTestClient()
 
-	games, err := GetCurrentWeekGames(FBS)
+	games, err := client.GetCurrentWeekGames(FBS)
 	if err != nil {
 		t.Fatalf("GetCurrentWeekGames: %v", err)
 	}
@@ -82,8 +92,9 @@ func TestGetCurrentWeekGames(t *testing.T) {
 func TestGetGamesByWeek(t *testing.T) {
 	ts := setupTestServer(t)
 	overrideURLs(t, ts.URL)
+	client := newTestClient()
 
-	res, err := GetGamesByWeek(2023, 1, FBS, Regular)
+	res, err := client.GetGamesByWeek(2023, 1, FBS, Regular)
 	if err != nil {
 		t.Fatalf("GetGamesByWeek: %v", err)
 	}
@@ -102,8 +113,9 @@ func TestGetGamesByWeek(t *testing.T) {
 func TestGetCompletedGamesByWeek(t *testing.T) {
 	ts := setupTestServer(t)
 	overrideURLs(t, ts.URL)
+	client := newTestClient()
 
-	games, err := GetCompletedGamesByWeek(2023, 1, FBS, Regular)
+	games, err := client.GetCompletedGamesByWeek(2023, 1, FBS, Regular)
 	if err != nil {
 		t.Fatalf("GetCompletedGamesByWeek: %v", err)
 	}
@@ -116,8 +128,9 @@ func TestGetCompletedGamesByWeek(t *testing.T) {
 func TestGetWeeksInSeason(t *testing.T) {
 	ts := setupTestServer(t)
 	overrideURLs(t, ts.URL)
+	client := newTestClient()
 
-	weeks, err := GetWeeksInSeason(2023)
+	weeks, err := client.GetWeeksInSeason(2023)
 	if err != nil {
 		t.Fatalf("GetWeeksInSeason: %v", err)
 	}
@@ -131,11 +144,12 @@ func TestGetWeeksInSeason(t *testing.T) {
 func TestHasPostseasonStarted(t *testing.T) {
 	ts := setupTestServer(t)
 	overrideURLs(t, ts.URL)
+	client := newTestClient()
 
 	// Postseason starts 2023-12-16T08:00Z
 	// Test with time before postseason
 	before := time.Date(2023, 12, 1, 0, 0, 0, 0, time.UTC)
-	started, err := HasPostseasonStarted(2023, before)
+	started, err := client.HasPostseasonStarted(2023, before)
 	if err != nil {
 		t.Fatalf("HasPostseasonStarted: %v", err)
 	}
@@ -145,7 +159,7 @@ func TestHasPostseasonStarted(t *testing.T) {
 
 	// Test with time after postseason
 	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	started, err = HasPostseasonStarted(2023, after)
+	started, err = client.HasPostseasonStarted(2023, after)
 	if err != nil {
 		t.Fatalf("HasPostseasonStarted: %v", err)
 	}
@@ -157,8 +171,9 @@ func TestHasPostseasonStarted(t *testing.T) {
 func TestGetGameStats(t *testing.T) {
 	ts := setupTestServer(t)
 	overrideURLs(t, ts.URL)
+	client := newTestClient()
 
-	res, err := GetGameStats(1001)
+	res, err := client.GetGameStats(1001)
 	if err != nil {
 		t.Fatalf("GetGameStats: %v", err)
 	}
@@ -187,8 +202,9 @@ func TestGetGameStats(t *testing.T) {
 func TestGetTeamInfo(t *testing.T) {
 	ts := setupTestServer(t)
 	overrideURLs(t, ts.URL)
+	client := newTestClient()
 
-	res, err := GetTeamInfo()
+	res, err := client.GetTeamInfo()
 	if err != nil {
 		t.Fatalf("GetTeamInfo: %v", err)
 	}
@@ -214,8 +230,9 @@ func TestGetTeamInfo(t *testing.T) {
 func TestDefaultSeason(t *testing.T) {
 	ts := setupTestServer(t)
 	overrideURLs(t, ts.URL)
+	client := newTestClient()
 
-	year, err := DefaultSeason()
+	year, err := client.DefaultSeason()
 	if err != nil {
 		t.Fatalf("DefaultSeason: %v", err)
 	}
@@ -235,8 +252,9 @@ func TestMakeRequestNon2xx(t *testing.T) {
 
 	restore := SetTestURLs(ts.URL+"/schedule", "", "")
 	t.Cleanup(restore)
+	client := newTestClient()
 
-	_, err := DefaultSeason()
+	_, err := client.DefaultSeason()
 	if err == nil {
 		t.Fatal("expected error for 404 response, got nil")
 	}
@@ -256,8 +274,9 @@ func TestMakeRequestMalformedJSON(t *testing.T) {
 
 	restore := SetTestURLs(ts.URL+"/schedule", "", "")
 	t.Cleanup(restore)
+	client := newTestClient()
 
-	_, err := DefaultSeason()
+	_, err := client.DefaultSeason()
 	if err == nil {
 		t.Fatal("expected error for malformed JSON, got nil")
 	}
@@ -277,8 +296,9 @@ func TestMakeRequestEmptyResponse(t *testing.T) {
 
 	restore := SetTestURLs(ts.URL+"/schedule", "", "")
 	t.Cleanup(restore)
+	client := newTestClient()
 
-	_, err := DefaultSeason()
+	_, err := client.DefaultSeason()
 	if err == nil {
 		t.Fatal("expected validation error for empty response, got nil")
 	}

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -118,7 +118,8 @@ func TestGetSingleGame(t *testing.T) {
 	ts := setupGameTestServer(t)
 	overrideGameURLs(t, ts.URL)
 
-	parsed, err := GetSingleGame(1001)
+	client := espn.NewClient()
+	parsed, err := GetSingleGame(client, 1001)
 	if err != nil {
 		t.Fatalf("GetSingleGame: %v", err)
 	}
@@ -153,7 +154,8 @@ func TestGetCurrentWeekGames(t *testing.T) {
 	ts := setupGameTestServer(t)
 	overrideGameURLs(t, ts.URL)
 
-	games, err := GetCurrentWeekGames()
+	client := espn.NewClient()
+	games, err := GetCurrentWeekGames(client)
 	if err != nil {
 		t.Fatalf("GetCurrentWeekGames: %v", err)
 	}

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -25,10 +25,10 @@ type ParsedTeamInfo struct {
 	Slug             string
 }
 
-func GetTeamInfo() ([]ParsedTeamInfo, error) {
+func GetTeamInfo(client *espn.Client) ([]ParsedTeamInfo, error) {
 	var parsedTeamInfo []ParsedTeamInfo
 
-	res, err := espn.GetTeamInfo()
+	res, err := client.GetTeamInfo()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/updater/update_games.go
+++ b/internal/updater/update_games.go
@@ -167,7 +167,7 @@ func (u *Updater) insertGameInfo(game *game.ParsedGameInfo) error {
 }
 
 func (u *Updater) UpdateCurrentWeek() ([]int64, error) {
-	games, err := game.GetCurrentWeekGames()
+	games, err := game.GetCurrentWeekGames(u.ESPN)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func (u *Updater) UpdateCurrentWeek() ([]int64, error) {
 		return nil, err
 	}
 
-	gameStats, err := game.GetGameStats(games)
+	gameStats, err := game.GetGameStats(u.ESPN, games)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func (u *Updater) UpdateCurrentWeek() ([]int64, error) {
 }
 
 func (u *Updater) UpdateGamesForYear(year int64) ([]int64, error) {
-	games, err := game.GetGamesForSeason(year)
+	games, err := game.GetGamesForSeason(u.ESPN, year)
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func (u *Updater) UpdateGamesForYear(year int64) ([]int64, error) {
 		return nil, err
 	}
 
-	gameStats, err := game.GetGameStats(games)
+	gameStats, err := game.GetGameStats(u.ESPN, games)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +221,7 @@ func (u *Updater) UpdateGamesForYear(year int64) ([]int64, error) {
 }
 
 func (u *Updater) UpdateSingleGame(gameID int64) error {
-	gameStats, err := game.GetSingleGame(gameID)
+	gameStats, err := game.GetSingleGame(u.ESPN, gameID)
 	if err != nil {
 		return err
 	}

--- a/internal/updater/update_team_info.go
+++ b/internal/updater/update_team_info.go
@@ -61,7 +61,7 @@ func (u *Updater) insertTeamsToDB(teams []database.TeamName) error {
 }
 
 func (u *Updater) UpdateTeamInfo() (int, error) {
-	teamInfo, err := team.GetTeamInfo()
+	teamInfo, err := team.GetTeamInfo(u.ESPN)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/updater/update_team_season.go
+++ b/internal/updater/update_team_season.go
@@ -35,7 +35,7 @@ func (u *Updater) seasonsExist(year int64) bool {
 }
 
 func (u *Updater) UpdateTeamSeasons(force bool) (int, error) {
-	currentSeason, err := espn.DefaultSeason()
+	currentSeason, err := u.ESPN.DefaultSeason()
 	if err != nil {
 		return 0, err
 	}
@@ -45,7 +45,7 @@ func (u *Updater) UpdateTeamSeasons(force bool) (int, error) {
 		return 0, nil
 	}
 
-	conferences, err := espn.ConferenceMap()
+	conferences, err := u.ESPN.ConferenceMap()
 	if err != nil {
 		return 0, err
 	}
@@ -53,7 +53,7 @@ func (u *Updater) UpdateTeamSeasons(force bool) (int, error) {
 	fbsfcs := maps.Clone(fbs)
 	maps.Copy(fbsfcs, conferences[espn.FCS].(map[int64]string))
 
-	teamConfs, err := espn.TeamConferencesByYear(currentSeason)
+	teamConfs, err := u.ESPN.TeamConferencesByYear(currentSeason)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -4,6 +4,7 @@ import (
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 
+	"github.com/robby-barton/stats-go/internal/espn"
 	"github.com/robby-barton/stats-go/internal/writer"
 )
 
@@ -11,4 +12,5 @@ type Updater struct {
 	DB     *gorm.DB
 	Logger *zap.SugaredLogger
 	Writer writer.Writer
+	ESPN   *espn.Client
 }


### PR DESCRIPTION
## Summary

- Introduce `espn.Client` struct with configurable `MaxRetries`, `InitialBackoff`, `RequestTimeout`, and `RateLimit` fields (replacing compile-time constants)
- Replace fixed 1s retry sleep with exponential backoff: `initialBackoff * 2^attempt`, capped at 30s
- Convert all ESPN package-level functions to methods on `*Client`
- Thread `*espn.Client` through `game`, `team`, and `updater` packages
- Add `ESPN *espn.Client` field to `Updater` struct, wired in `cmd/updater`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes with zero issues
- [ ] Manual smoke test with `updater games` to verify real ESPN API calls use new backoff