### PR TITLE
Add integration tests for updater package

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,13 @@ jobs:
   test:
     name: Test
     uses: ./.github/workflows/test.yml
+  integration-test:
+    name: Integration Test
+    uses: ./.github/workflows/integration-test.yml
   deploy:
     name: Build and push
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, test, integration-test]
     steps:
       - name: Checkout master
         uses: actions/checkout@v2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,16 +1,16 @@
-name: Test
+name: Integration Test
 
 on:
   workflow_call:
 
 jobs:
-  test:
-    name: test
+  integration-test:
+    name: integration-test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: '1.26'
-      - name: Run tests
-        run: go test ./...
+      - name: Run integration tests
+        run: go test -tags=integration -count=1 ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.26'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,3 +16,6 @@ jobs:
   test:
     name: Test
     uses: ./.github/workflows/test.yml
+  integration-test:
+    name: Integration Test
+    uses: ./.github/workflows/integration-test.yml

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt refresh-module download-modules modules clean migrate updater ranker
+.PHONY: fmt refresh-module download-modules modules clean migrate updater ranker test test-integration test-all
 
 format:
 	@go fmt ./...
@@ -28,6 +28,15 @@ modules:
 clean:
 	@rm -rf migrate updater ranker > /dev/null 2>&1
 	@rm -rf ranking team teams.json availRanks.json latest.json gameCount.json > /dev/null 2>&1
+
+test:
+	@go test ./...
+
+test-integration:
+	@go test -tags=integration -count=1 ./...
+
+test-all:
+	@go test -tags=integration ./...
 
 lint:
 	@golangci-lint run --config=.golangci.yml ./cmd/... ./internal/...

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -2,10 +2,11 @@
 
 ## Active
 
-### No integration tests
-Unit tests cover ESPN parsing, ranking math, and record formatting. There are no
-integration tests that exercise the full pipeline (fetch → parse → store →
-rank → export) against a real or in-memory database.
+### ~~No integration tests~~ (resolved 2026-02-13)
+Added integration tests in `internal/updater/` behind a `//go:build integration`
+tag. Tests exercise the full pipeline (fetch → parse → store → rank → export)
+against an in-memory SQLite database with a mock ESPN HTTP server and a
+capturing writer. CI runs integration tests as a separate job.
 
 ### ~~ESPN API fragility~~ (resolved 2026-02-13)
 Added HTTP status code validation and 5xx retry in `makeRequest`, wrapped JSON

--- a/internal/updater/testhelper_test.go
+++ b/internal/updater/testhelper_test.go
@@ -1,0 +1,570 @@
+//go:build integration
+
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/robby-barton/stats-go/internal/database"
+	"github.com/robby-barton/stats-go/internal/espn"
+)
+
+// ---------------------------------------------------------------------------
+// Test database
+// ---------------------------------------------------------------------------
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+
+	if err := db.AutoMigrate(
+		&database.Game{},
+		&database.TeamSeason{},
+		&database.TeamName{},
+		&database.TeamWeekResult{},
+		&database.TeamGameStats{},
+		&database.PassingStats{},
+		&database.RushingStats{},
+		&database.ReceivingStats{},
+		&database.FumbleStats{},
+		&database.DefensiveStats{},
+		&database.InterceptionStats{},
+		&database.ReturnStats{},
+		&database.KickStats{},
+		&database.PuntStats{},
+	); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+
+	return db
+}
+
+// ---------------------------------------------------------------------------
+// Capturing writer
+// ---------------------------------------------------------------------------
+
+type capturingWriter struct {
+	mu         sync.Mutex
+	data       map[string]any
+	purgeCount int
+}
+
+func newCapturingWriter() *capturingWriter {
+	return &capturingWriter{data: map[string]any{}}
+}
+
+func (w *capturingWriter) WriteData(_ context.Context, fileName string, data any) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.data[fileName] = data
+	return nil
+}
+
+func (w *capturingWriter) PurgeCache(_ context.Context) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.purgeCount++
+	return nil
+}
+
+func (w *capturingWriter) hasFile(name string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	_, ok := w.data[name]
+	return ok
+}
+
+func (w *capturingWriter) fileCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return len(w.data)
+}
+
+// ---------------------------------------------------------------------------
+// Fixture data — 4 teams, 2 conferences, 6 games across 2 weeks
+// ---------------------------------------------------------------------------
+
+// Team IDs:
+//
+//	1 = Alpha (SEC, FBS)
+//	2 = Beta  (SEC, FBS)
+//	3 = Gamma (Big Ten, FBS)
+//	4 = Delta (Big Ten, FBS)
+//
+// Week 1 games (2023-09-02, Saturday = dow 6):
+//
+//	Game 401001: Alpha 28 – Beta 14  (conf game)
+//	Game 401002: Gamma 21 – Delta 10 (conf game)
+//	Game 401003: in-progress, should be filtered
+//
+// Week 2 games (2023-09-09, Saturday = dow 6):
+//
+//	Game 401004: Alpha 35 – Gamma 17
+//	Game 401005: Beta 24 – Delta 21
+//	Game 401006: in-progress, should be filtered
+
+const (
+	fixtureGameID1 int64 = 401001
+	fixtureGameID2 int64 = 401002
+	fixtureGameID3 int64 = 401003 // in-progress
+	fixtureGameID4 int64 = 401004
+	fixtureGameID5 int64 = 401005
+	fixtureGameID6 int64 = 401006 // in-progress
+)
+
+func fixtureScheduleResponse() espn.GameScheduleESPN {
+	return espn.GameScheduleESPN{
+		Content: espn.Content{
+			Schedule: map[string]espn.Day{
+				"2023-09-02": {
+					Games: []espn.Game{
+						newFinalGame(fixtureGameID1, 1, 100, 28, 2, 100, 14),
+						newFinalGame(fixtureGameID2, 3, 200, 21, 4, 200, 10),
+						newInProgressGame(fixtureGameID3, 5, 100, 7, 6, 200, 3),
+					},
+				},
+				"2023-09-09": {
+					Games: []espn.Game{
+						newFinalGame(fixtureGameID4, 1, 100, 35, 3, 200, 17),
+						newFinalGame(fixtureGameID5, 2, 100, 24, 4, 200, 21),
+						newInProgressGame(fixtureGameID6, 5, 100, 14, 6, 200, 10),
+					},
+				},
+			},
+			Parameters: espn.Parameters{Week: 1, Year: 2023, SeasonType: 2, Group: 80},
+			Defaults:   espn.Parameters{Week: 1, Year: 2023, SeasonType: 2, Group: 80},
+			Calendar: []espn.Calendar{
+				{
+					StartDate:  "2023-08-26T07:00Z",
+					EndDate:    "2023-12-03T07:59Z",
+					SeasonType: 2,
+					Weeks: []espn.Week{
+						{Num: 1, StartDate: "2023-09-04T07:00Z", EndDate: "2023-09-11T06:59Z"},
+						{Num: 2, StartDate: "2023-09-11T07:00Z", EndDate: "2023-09-18T06:59Z"},
+					},
+				},
+				{
+					StartDate:  "2023-12-16T08:00Z",
+					EndDate:    "2024-01-09T07:59Z",
+					SeasonType: 3,
+					Weeks: []espn.Week{
+						{Num: 1, StartDate: "2023-12-16T08:00Z", EndDate: "2024-01-09T07:59Z"},
+					},
+				},
+			},
+			ConferenceAPI: espn.ConferenceAPI{
+				Conferences: []espn.Conference{
+					{GroupID: 100, Name: "Southeastern Conference", ShortName: "SEC", ParentGroupID: 80},
+					{GroupID: 200, Name: "Big Ten Conference", ShortName: "Big Ten", ParentGroupID: 80},
+					{GroupID: 300, Name: "Missouri Valley", ShortName: "MVFC", ParentGroupID: 81},
+				},
+			},
+		},
+	}
+}
+
+func newFinalGame(id int64, homeID, homeConf, homeScore, awayID, awayConf, awayScore int64) espn.Game {
+	return espn.Game{
+		ID: id,
+		Status: espn.Status{StatusType: espn.StatusType{
+			Name: "STATUS_FINAL", Completed: true,
+		}},
+		Competitions: []espn.Competition{{
+			Competitors: []espn.Competitor{
+				{ID: homeID, Team: espn.ScheduleTeam{ID: homeID, ConferenceID: homeConf}, Score: homeScore, HomeAway: "home"},
+				{ID: awayID, Team: espn.ScheduleTeam{ID: awayID, ConferenceID: awayConf}, Score: awayScore, HomeAway: "away"},
+			},
+		}},
+	}
+}
+
+func newInProgressGame(id int64, homeID, homeConf, homeScore, awayID, awayConf, awayScore int64) espn.Game {
+	return espn.Game{
+		ID: id,
+		Status: espn.Status{StatusType: espn.StatusType{
+			Name: "STATUS_IN_PROGRESS", Completed: false,
+		}},
+		Competitions: []espn.Competition{{
+			Competitors: []espn.Competitor{
+				{ID: homeID, Team: espn.ScheduleTeam{ID: homeID, ConferenceID: homeConf}, Score: homeScore, HomeAway: "home"},
+				{ID: awayID, Team: espn.ScheduleTeam{ID: awayID, ConferenceID: awayConf}, Score: awayScore, HomeAway: "away"},
+			},
+		}},
+	}
+}
+
+func fixtureGameInfoResponse(gameID int64) espn.GameInfoESPN {
+	games := map[int64]espn.GameInfoESPN{
+		fixtureGameID1: newGameInfo(fixtureGameID1, 1, 28, 2, 14, 2023, 1, true),
+		fixtureGameID2: newGameInfo(fixtureGameID2, 3, 21, 4, 10, 2023, 1, true),
+		fixtureGameID4: newGameInfo(fixtureGameID4, 1, 35, 3, 17, 2023, 2, false),
+		fixtureGameID5: newGameInfo(fixtureGameID5, 2, 24, 4, 21, 2023, 2, false),
+	}
+	if g, ok := games[gameID]; ok {
+		return g
+	}
+	// Fallback for unknown game IDs
+	return newGameInfo(gameID, 1, 0, 2, 0, 2023, 1, false)
+}
+
+func newGameInfo(
+	gameID, homeID, homeScore, awayID, awayScore, year, week int64,
+	confGame bool,
+) espn.GameInfoESPN {
+	dateStr := "2023-09-02T23:00Z"
+	if week == 2 {
+		dateStr = "2023-09-09T23:00Z"
+	}
+	return espn.GameInfoESPN{
+		GamePackage: espn.GamePackage{
+			Header: espn.Header{
+				ID: gameID,
+				Competitions: []espn.Competitions{{
+					ID:       gameID,
+					Date:     dateStr,
+					ConfGame: confGame,
+					Neutral:  false,
+					Competitors: []espn.Competitors{
+						{HomeAway: "home", ID: homeID, Score: homeScore},
+						{HomeAway: "away", ID: awayID, Score: awayScore},
+					},
+					Status: espn.Status{StatusType: espn.StatusType{
+						Name: "STATUS_FINAL", Completed: true,
+					}},
+				}},
+				Season: espn.Season{Year: year, Type: 2},
+				Week:   week,
+			},
+			Boxscore: espn.Boxscore{
+				Teams: []espn.Teams{
+					{
+						Team: espn.Team{ID: homeID},
+						Statistics: []espn.TeamStatistics{
+							{Name: "firstDowns", DisplayValue: "22"},
+							{Name: "totalYards", DisplayValue: "450"},
+							{Name: "netPassingYards", DisplayValue: "250"},
+							{Name: "completionAttempts", DisplayValue: "20/30"},
+							{Name: "rushingYards", DisplayValue: "200"},
+							{Name: "rushingAttempts", DisplayValue: "35"},
+							{Name: "totalPenaltiesYards", DisplayValue: "5-40"},
+							{Name: "fumblesLost", DisplayValue: "1"},
+							{Name: "interceptions", DisplayValue: "0"},
+							{Name: "possessionTime", DisplayValue: "32:15"},
+							{Name: "thirdDownEff", DisplayValue: "6-12"},
+							{Name: "fourthDownEff", DisplayValue: "1-2"},
+						},
+					},
+					{
+						Team: espn.Team{ID: awayID},
+						Statistics: []espn.TeamStatistics{
+							{Name: "firstDowns", DisplayValue: "15"},
+							{Name: "totalYards", DisplayValue: "300"},
+							{Name: "netPassingYards", DisplayValue: "180"},
+							{Name: "completionAttempts", DisplayValue: "15/25"},
+							{Name: "rushingYards", DisplayValue: "120"},
+							{Name: "rushingAttempts", DisplayValue: "25"},
+							{Name: "totalPenaltiesYards", DisplayValue: "7-55"},
+							{Name: "fumblesLost", DisplayValue: "2"},
+							{Name: "interceptions", DisplayValue: "1"},
+							{Name: "possessionTime", DisplayValue: "27:45"},
+							{Name: "thirdDownEff", DisplayValue: "4-10"},
+							{Name: "fourthDownEff", DisplayValue: "0-1"},
+						},
+					},
+				},
+				Players: []espn.Players{
+					{
+						Team: espn.Team{ID: homeID},
+						Statistics: []espn.PlayerStatistics{
+							{
+								Name:   "passing",
+								Labels: []string{"C/ATT", "YDS", "TD", "INT"},
+								Totals: []string{"20/30", "250", "3", "0"},
+								Athletes: []espn.AthleteStats{
+									{
+										Athlete: espn.Athlete{ID: homeID*100 + 1, FirstName: "QB", LastName: "Home"},
+										Stats:   []string{"20/30", "250", "3", "0"},
+									},
+								},
+							},
+							{
+								Name:   "rushing",
+								Labels: []string{"CAR", "YDS", "TD", "LONG"},
+								Totals: []string{"35", "200", "1", "45"},
+								Athletes: []espn.AthleteStats{
+									{
+										Athlete: espn.Athlete{ID: homeID*100 + 2, FirstName: "RB", LastName: "Home"},
+										Stats:   []string{"35", "200", "1", "45"},
+									},
+								},
+							},
+						},
+					},
+					{
+						Team: espn.Team{ID: awayID},
+						Statistics: []espn.PlayerStatistics{
+							{
+								Name:   "passing",
+								Labels: []string{"C/ATT", "YDS", "TD", "INT"},
+								Totals: []string{"15/25", "180", "1", "1"},
+								Athletes: []espn.AthleteStats{
+									{
+										Athlete: espn.Athlete{ID: awayID*100 + 1, FirstName: "QB", LastName: "Away"},
+										Stats:   []string{"15/25", "180", "1", "1"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func fixtureTeamInfoResponse() espn.TeamInfoESPN {
+	return espn.TeamInfoESPN{
+		Sports: []espn.Sport{{
+			ID:   90,
+			Name: "Football",
+			Slug: "football",
+			Leagues: []espn.League{{
+				ID:           23,
+				Name:         "National Collegiate Athletic Association",
+				Abbreviation: "NCAAF",
+				ShortName:    "NCAAF",
+				Slug:         "college-football",
+				Year:         2023,
+				Teams: []espn.TeamWrap{
+					{Team: espn.TeamInfo{
+						ID: 1, Name: "Crimson Tide", DisplayName: "Alpha Crimson Tide",
+						Abbreviation: "ALP", Location: "Alpha", Slug: "alpha",
+						IsActive: true,
+					}},
+					{Team: espn.TeamInfo{
+						ID: 2, Name: "Tigers", DisplayName: "Beta Tigers",
+						Abbreviation: "BET", Location: "Beta", Slug: "beta",
+						IsActive: true,
+					}},
+					{Team: espn.TeamInfo{
+						ID: 3, Name: "Wildcats", DisplayName: "Gamma Wildcats",
+						Abbreviation: "GAM", Location: "Gamma", Slug: "gamma",
+						IsActive: true,
+					}},
+					{Team: espn.TeamInfo{
+						ID: 4, Name: "Bulldogs", DisplayName: "Delta Bulldogs",
+						Abbreviation: "DEL", Location: "Delta", Slug: "delta",
+						IsActive: true,
+					}},
+				},
+			}},
+		}},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mock HTTP server
+// ---------------------------------------------------------------------------
+
+// setupTestServer creates an httptest.Server that serves fixture data for all
+// ESPN endpoints. The optional scoreOverride lets tests swap in different scores
+// for a specific game ID (used by the score-change test). The override applies
+// to both the schedule and game info endpoints.
+func setupTestServer(t *testing.T, scoreOverride map[int64][2]int64) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/core/college-football/schedule", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := fixtureScheduleResponse()
+		if scoreOverride != nil {
+			for date, day := range resp.Content.Schedule {
+				for i, g := range day.Games {
+					if scores, ok := scoreOverride[g.ID]; ok {
+						for j := range g.Competitions[0].Competitors {
+							if g.Competitions[0].Competitors[j].HomeAway == "home" {
+								g.Competitions[0].Competitors[j].Score = scores[0]
+							} else {
+								g.Competitions[0].Competitors[j].Score = scores[1]
+							}
+						}
+						day.Games[i] = g
+					}
+				}
+				resp.Content.Schedule[date] = day
+			}
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+
+	mux.HandleFunc("/core/college-football/playbyplay", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		gameIDStr := r.URL.Query().Get("gameId")
+		var gameID int64
+		fmt.Sscanf(gameIDStr, "%d", &gameID) //nolint:errcheck // test helper
+
+		resp := fixtureGameInfoResponse(gameID)
+		if scoreOverride != nil {
+			if scores, ok := scoreOverride[gameID]; ok {
+				comps := resp.GamePackage.Header.Competitions[0].Competitors
+				for i := range comps {
+					if comps[i].HomeAway == "home" {
+						comps[i].Score = scores[0]
+					} else {
+						comps[i].Score = scores[1]
+					}
+				}
+				resp.GamePackage.Header.Competitions[0].Competitors = comps
+			}
+		}
+
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+
+	mux.HandleFunc("/apis/site/v2/sports/football/college-football/teams", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(fixtureTeamInfoResponse()); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// ---------------------------------------------------------------------------
+// Test Updater constructor
+// ---------------------------------------------------------------------------
+
+func newTestUpdater(t *testing.T, scoreOverride map[int64][2]int64) (*Updater, *capturingWriter) {
+	t.Helper()
+
+	db := setupTestDB(t)
+	cw := newCapturingWriter()
+	ts := setupTestServer(t, scoreOverride)
+
+	restore := espn.SetTestURLs(
+		ts.URL+"/core/college-football/schedule?xhr=1&render=false&userab=18",
+		ts.URL+"/core/college-football/playbyplay?gameId=%d&xhr=1&render=false&userab=18",
+		ts.URL+"/apis/site/v2/sports/football/college-football/teams?limit=1000",
+	)
+	t.Cleanup(restore)
+
+	client := &espn.Client{
+		MaxRetries:     2,
+		InitialBackoff: 10 * time.Millisecond,
+		RequestTimeout: 5 * time.Second,
+		RateLimit:      0,
+	}
+
+	u := &Updater{
+		DB:     db,
+		Logger: zap.NewNop().Sugar(),
+		Writer: cw,
+		ESPN:   client,
+	}
+
+	return u, cw
+}
+
+// seedTeamsAndSeasons inserts teams and seasons into the test database
+// so that ranking and JSON-export tests have team context available.
+// Includes 4 FBS teams and 2 FCS teams to exercise both ranking paths.
+func seedTeamsAndSeasons(t *testing.T, db *gorm.DB) {
+	t.Helper()
+
+	teamNames := []database.TeamName{
+		{TeamID: 1, Name: "Alpha", DisplayName: "Alpha Crimson Tide", Abbreviation: "ALP", Location: "Alpha", Slug: "alpha", IsActive: true},
+		{TeamID: 2, Name: "Beta", DisplayName: "Beta Tigers", Abbreviation: "BET", Location: "Beta", Slug: "beta", IsActive: true},
+		{TeamID: 3, Name: "Gamma", DisplayName: "Gamma Wildcats", Abbreviation: "GAM", Location: "Gamma", Slug: "gamma", IsActive: true},
+		{TeamID: 4, Name: "Delta", DisplayName: "Delta Bulldogs", Abbreviation: "DEL", Location: "Delta", Slug: "delta", IsActive: true},
+		{TeamID: 5, Name: "Epsilon", DisplayName: "Epsilon Eagles", Abbreviation: "EPS", Location: "Epsilon", Slug: "epsilon", IsActive: true},
+		{TeamID: 6, Name: "Zeta", DisplayName: "Zeta Falcons", Abbreviation: "ZET", Location: "Zeta", Slug: "zeta", IsActive: true},
+	}
+	if err := db.Create(&teamNames).Error; err != nil {
+		t.Fatalf("seed team_names: %v", err)
+	}
+
+	teamSeasons := []database.TeamSeason{
+		{TeamID: 1, Year: 2023, FBS: 1, Conf: "SEC"},
+		{TeamID: 2, Year: 2023, FBS: 1, Conf: "SEC"},
+		{TeamID: 3, Year: 2023, FBS: 1, Conf: "Big Ten"},
+		{TeamID: 4, Year: 2023, FBS: 1, Conf: "Big Ten"},
+		{TeamID: 5, Year: 2023, FBS: 0, Conf: "MVFC"},
+		{TeamID: 6, Year: 2023, FBS: 0, Conf: "MVFC"},
+	}
+	if err := db.Create(&teamSeasons).Error; err != nil {
+		t.Fatalf("seed team_seasons: %v", err)
+	}
+}
+
+// seedGames inserts completed fixture games directly into the database.
+// Includes 4 FBS games and 2 FCS games.
+func seedGames(t *testing.T, db *gorm.DB) {
+	t.Helper()
+
+	games := []database.Game{
+		// FBS games
+		{
+			GameID: fixtureGameID1, Season: 2023, Week: 1,
+			HomeID: 1, AwayID: 2, HomeScore: 28, AwayScore: 14,
+			ConfGame: true,
+			StartTime: time.Date(2023, 9, 2, 23, 0, 0, 0, time.UTC),
+		},
+		{
+			GameID: fixtureGameID2, Season: 2023, Week: 1,
+			HomeID: 3, AwayID: 4, HomeScore: 21, AwayScore: 10,
+			ConfGame: true,
+			StartTime: time.Date(2023, 9, 2, 23, 0, 0, 0, time.UTC),
+		},
+		{
+			GameID: fixtureGameID4, Season: 2023, Week: 2,
+			HomeID: 1, AwayID: 3, HomeScore: 35, AwayScore: 17,
+			StartTime: time.Date(2023, 9, 9, 23, 0, 0, 0, time.UTC),
+		},
+		{
+			GameID: fixtureGameID5, Season: 2023, Week: 2,
+			HomeID: 2, AwayID: 4, HomeScore: 24, AwayScore: 21,
+			StartTime: time.Date(2023, 9, 9, 23, 0, 0, 0, time.UTC),
+		},
+		// FCS games
+		{
+			GameID: 501001, Season: 2023, Week: 1,
+			HomeID: 5, AwayID: 6, HomeScore: 17, AwayScore: 10,
+			ConfGame: true,
+			StartTime: time.Date(2023, 9, 2, 20, 0, 0, 0, time.UTC),
+		},
+		{
+			GameID: 501002, Season: 2023, Week: 2,
+			HomeID: 6, AwayID: 5, HomeScore: 14, AwayScore: 21,
+			ConfGame: true,
+			StartTime: time.Date(2023, 9, 9, 20, 0, 0, 0, time.UTC),
+		},
+	}
+	if err := db.Create(&games).Error; err != nil {
+		t.Fatalf("seed games: %v", err)
+	}
+}

--- a/internal/updater/update_games.go
+++ b/internal/updater/update_games.go
@@ -134,8 +134,13 @@ func (u *Updater) insertGameInfo(game *game.ParsedGameInfo) error {
 		if len(game.ReturnStats) > 0 {
 			if err := tx.
 				Clauses(clause.OnConflict{
-					UpdateAll:    true, // upsert
-					OnConstraint: "return_stats_pkey",
+					UpdateAll: true, // upsert
+					Columns: []clause.Column{
+						{Name: "player_id"},
+						{Name: "team_id"},
+						{Name: "game_id"},
+						{Name: "punt_kick"},
+					},
 				}).
 				Create(&game.ReturnStats).Error; err != nil {
 				return err

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,290 @@
+//go:build integration
+
+package updater
+
+import (
+	"testing"
+
+	"github.com/robby-barton/stats-go/internal/database"
+	"github.com/robby-barton/stats-go/internal/espn"
+)
+
+func TestUpdateSingleGame(t *testing.T) {
+	u, _ := newTestUpdater(t, nil)
+
+	if err := u.UpdateSingleGame(fixtureGameID1); err != nil {
+		t.Fatalf("UpdateSingleGame: %v", err)
+	}
+
+	// Verify game row
+	var game database.Game
+	if err := u.DB.Where("game_id = ?", fixtureGameID1).First(&game).Error; err != nil {
+		t.Fatalf("game not found: %v", err)
+	}
+	if game.HomeScore != 28 || game.AwayScore != 14 {
+		t.Errorf("scores = %d-%d, want 28-14", game.HomeScore, game.AwayScore)
+	}
+	if game.HomeID != 1 || game.AwayID != 2 {
+		t.Errorf("teams = %d vs %d, want 1 vs 2", game.HomeID, game.AwayID)
+	}
+	if game.Season != 2023 || game.Week != 1 {
+		t.Errorf("season/week = %d/%d, want 2023/1", game.Season, game.Week)
+	}
+
+	// Verify team stats were inserted
+	var teamStats []database.TeamGameStats
+	if err := u.DB.Where("game_id = ?", fixtureGameID1).Find(&teamStats).Error; err != nil {
+		t.Fatalf("team stats query: %v", err)
+	}
+	if len(teamStats) != 2 {
+		t.Errorf("len(teamStats) = %d, want 2", len(teamStats))
+	}
+
+	// Verify passing stats were inserted
+	var passStats []database.PassingStats
+	if err := u.DB.Where("game_id = ?", fixtureGameID1).Find(&passStats).Error; err != nil {
+		t.Fatalf("passing stats query: %v", err)
+	}
+	if len(passStats) == 0 {
+		t.Error("expected passing stats, got none")
+	}
+}
+
+func TestUpdateCurrentWeek(t *testing.T) {
+	u, _ := newTestUpdater(t, nil)
+
+	gameIDs, err := u.UpdateCurrentWeek()
+	if err != nil {
+		t.Fatalf("UpdateCurrentWeek: %v", err)
+	}
+
+	// Mock server returns both FBS and FCS schedule with the same fixture.
+	// GetCurrentWeekGames deduplicates via combineGames.
+	// Fixture has 4 final games (IDs 401001, 401002, 401004, 401005)
+	// and 2 in-progress (filtered out).
+	if len(gameIDs) != 4 {
+		t.Fatalf("len(gameIDs) = %d, want 4", len(gameIDs))
+	}
+
+	idSet := map[int64]bool{}
+	for _, id := range gameIDs {
+		idSet[id] = true
+	}
+	for _, expected := range []int64{fixtureGameID1, fixtureGameID2, fixtureGameID4, fixtureGameID5} {
+		if !idSet[expected] {
+			t.Errorf("expected game %d in results", expected)
+		}
+	}
+
+	// Verify games in DB
+	var count int64
+	u.DB.Model(&database.Game{}).Count(&count)
+	if count != 4 {
+		t.Errorf("game count = %d, want 4", count)
+	}
+
+	// Re-run should be a no-op (checkGames filters already-stored games with matching scores)
+	gameIDs2, err := u.UpdateCurrentWeek()
+	if err != nil {
+		t.Fatalf("UpdateCurrentWeek re-run: %v", err)
+	}
+	if len(gameIDs2) != 0 {
+		t.Errorf("re-run returned %d games, want 0 (no-op)", len(gameIDs2))
+	}
+}
+
+func TestUpdateCurrentWeek_ScoreChange(t *testing.T) {
+	// First run: normal scores
+	u, _ := newTestUpdater(t, nil)
+
+	_, err := u.UpdateCurrentWeek()
+	if err != nil {
+		t.Fatalf("initial UpdateCurrentWeek: %v", err)
+	}
+
+	// Verify initial score
+	var game database.Game
+	u.DB.Where("game_id = ?", fixtureGameID1).First(&game)
+	if game.HomeScore != 28 {
+		t.Fatalf("initial home score = %d, want 28", game.HomeScore)
+	}
+
+	// Second run: override game 401001 scores to 31-14
+	// We need a new server with score override, and re-override the URLs
+	overrides := map[int64][2]int64{
+		fixtureGameID1: {31, 14},
+	}
+	ts2 := setupTestServer(t, overrides)
+	restore := newTestURLs(t, ts2.URL)
+	defer restore()
+
+	gameIDs, err := u.UpdateCurrentWeek()
+	if err != nil {
+		t.Fatalf("UpdateCurrentWeek with score change: %v", err)
+	}
+
+	// Only game 401001 should be re-fetched (score changed)
+	found := false
+	for _, id := range gameIDs {
+		if id == fixtureGameID1 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected game %d to be re-fetched due to score change", fixtureGameID1)
+	}
+
+	// Verify updated score in DB
+	u.DB.Where("game_id = ?", fixtureGameID1).First(&game)
+	if game.HomeScore != 31 {
+		t.Errorf("updated home score = %d, want 31", game.HomeScore)
+	}
+}
+
+func TestUpdateTeamInfo(t *testing.T) {
+	u, _ := newTestUpdater(t, nil)
+
+	count, err := u.UpdateTeamInfo()
+	if err != nil {
+		t.Fatalf("UpdateTeamInfo: %v", err)
+	}
+	if count != 4 {
+		t.Errorf("team count = %d, want 4", count)
+	}
+
+	// Verify team names in DB
+	var teams []database.TeamName
+	if err := u.DB.Find(&teams).Error; err != nil {
+		t.Fatalf("query teams: %v", err)
+	}
+	if len(teams) != 4 {
+		t.Errorf("len(teams) = %d, want 4", len(teams))
+	}
+
+	// Verify name parsing (display name minus nickname = school name)
+	teamMap := map[int64]string{}
+	for _, team := range teams {
+		teamMap[team.TeamID] = team.Name
+	}
+	if teamMap[1] != "Alpha" {
+		t.Errorf("team 1 name = %q, want %q", teamMap[1], "Alpha")
+	}
+}
+
+func TestUpdateTeamSeasons(t *testing.T) {
+	u, _ := newTestUpdater(t, nil)
+
+	count, err := u.UpdateTeamSeasons(true)
+	if err != nil {
+		t.Fatalf("UpdateTeamSeasons: %v", err)
+	}
+
+	// The mock conference map has 2 FBS conferences (conf IDs 100, 200).
+	// TeamConferencesByYear iterates weeks x groups and collects team->conf mappings.
+	// All fixture games use teams 1-6 with conf IDs 100, 200.
+	if count == 0 {
+		t.Error("expected at least some team seasons inserted")
+	}
+
+	var seasons []database.TeamSeason
+	if err := u.DB.Find(&seasons).Error; err != nil {
+		t.Fatalf("query seasons: %v", err)
+	}
+	if len(seasons) == 0 {
+		t.Error("no team_season rows found")
+	}
+
+	// Verify FBS assignment
+	for _, s := range seasons {
+		if s.TeamID >= 1 && s.TeamID <= 4 {
+			if s.FBS != 1 {
+				t.Errorf("team %d FBS = %d, want 1", s.TeamID, s.FBS)
+			}
+		}
+	}
+}
+
+func TestRankingForWeek(t *testing.T) {
+	u, _ := newTestUpdater(t, nil)
+
+	// Seed teams, seasons, and games directly
+	seedTeamsAndSeasons(t, u.DB)
+	seedGames(t, u.DB)
+
+	// Run ranking
+	if err := u.UpdateRecentRankings(); err != nil {
+		t.Fatalf("UpdateRecentRankings: %v", err)
+	}
+
+	// Verify TeamWeekResult rows exist
+	var results []database.TeamWeekResult
+	if err := u.DB.Find(&results).Error; err != nil {
+		t.Fatalf("query results: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("no ranking results found")
+	}
+
+	// Check that FBS teams got ranked
+	fbsResults := 0
+	for _, r := range results {
+		if r.Fbs {
+			fbsResults++
+			if r.FinalRank == 0 {
+				t.Errorf("team %d has FinalRank 0", r.TeamID)
+			}
+		}
+	}
+	if fbsResults != 4 {
+		t.Errorf("FBS results = %d, want 4", fbsResults)
+	}
+}
+
+func TestUpdateRecentJSON(t *testing.T) {
+	u, cw := newTestUpdater(t, nil)
+
+	// Seed the full pipeline: teams, seasons, games, rankings
+	seedTeamsAndSeasons(t, u.DB)
+	seedGames(t, u.DB)
+
+	if err := u.UpdateRecentRankings(); err != nil {
+		t.Fatalf("UpdateRecentRankings: %v", err)
+	}
+
+	// Run JSON export
+	if err := u.UpdateRecentJSON(); err != nil {
+		t.Fatalf("UpdateRecentJSON: %v", err)
+	}
+
+	// Verify expected files were written
+	expectedFiles := []string{
+		"availRanks.json",
+		"gameCount.json",
+		"latest.json",
+	}
+	for _, f := range expectedFiles {
+		if !cw.hasFile(f) {
+			t.Errorf("expected file %q not written", f)
+		}
+	}
+
+	// Verify ranking files were written (pattern: ranking/YEAR/DIVISION/WEEK.json)
+	if cw.fileCount() < len(expectedFiles) {
+		t.Errorf("total files = %d, want at least %d", cw.fileCount(), len(expectedFiles))
+	}
+
+	// Verify PurgeCache was called
+	if cw.purgeCount != 1 {
+		t.Errorf("PurgeCache count = %d, want 1", cw.purgeCount)
+	}
+}
+
+// newTestURLs is a helper that overrides ESPN URLs for a given test server base URL.
+func newTestURLs(t *testing.T, serverURL string) func() {
+	t.Helper()
+	return espn.SetTestURLs(
+		serverURL+"/core/college-football/schedule?xhr=1&render=false&userab=18",
+		serverURL+"/core/college-football/playbyplay?gameId=%d&xhr=1&render=false&userab=18",
+		serverURL+"/apis/site/v2/sports/football/college-football/teams?limit=1000",
+	)
+}


### PR DESCRIPTION
## Summary

- Add 7 integration tests in `internal/updater/` behind a `//go:build integration` tag that exercise the full pipeline (fetch → parse → store → rank → export) against an in-memory SQLite database with a mock ESPN HTTP server and a capturing writer
- Fix two SQLite compatibility issues in production code: `ReturnStats` upsert (`OnConstraint` → `Columns`) and `UpdateGameCountJSON` (dialect-aware day-of-week SQL, remove parenthesized `UNION ALL`)
- Add dedicated CI workflow for integration tests, wire into PR and deploy pipelines, and fix stale Go version (1.21 → 1.26) in `test.yml` and `lint.yml`

## Test plan

- [x] `go test ./...` — unit tests pass
- [x] `go test -tags=integration -count=1 ./...` — all 7 integration tests pass
- [x] `golangci-lint run --config=.golangci.yml ./cmd/... ./internal/...` — 0 issues
- [x] `make test` and `make test-integration` targets work