### PR TITLE
Add college basketball support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -151,7 +151,9 @@ by whether `DBParams` is nil (nil → SQLite).
 All models use composite primary keys for multi-dimensional lookups
 (team+year, game+team, etc.). Shared tables (`games`, `team_names`,
 `team_seasons`, `team_week_results`) include a `sport` column with a default of
-`"cfb"`. The `team_seasons` and `team_week_results` primary keys include `sport`.
+`"cfb"`. The `team_names`, `team_seasons`, and `team_week_results` primary keys
+include `sport`. ESPN uses the same team IDs across sports for the same school,
+so `team_names` requires `(team_id, sport)` to store per-sport team metadata.
 
 ## Deployment
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,8 +2,9 @@
 
 ## System Overview
 
-stats-go is a set of Go services for ranking college football teams. Data flows
-in one direction: ESPN API -> parsing -> database -> ranking algorithm -> output.
+stats-go is a set of Go services for ranking college sports teams (football and
+basketball). Data flows in one direction: ESPN API -> parsing -> database ->
+ranking algorithm -> output.
 
 ```
 ┌─────────────────────────────────────────────────────────┐
@@ -13,7 +14,7 @@ in one direction: ESPN API -> parsing -> database -> ranking algorithm -> output
               ┌────────────▼────────────┐
               │     internal/espn       │  Pure HTTP client
               │  (schedules, stats,     │  No DB dependency
-              │   team info)            │
+              │   team info)            │  Sport-parameterized
               └────────────┬────────────┘
                            │
               ┌────────────▼────────────┐
@@ -23,7 +24,7 @@ in one direction: ESPN API -> parsing -> database -> ranking algorithm -> output
                            │
               ┌────────────▼────────────┐
               │   internal/database     │  GORM models (14 tables)
-              │  (Postgres or SQLite)   │  Shared by all services
+              │  (Postgres or SQLite)   │  Sport column on shared tables
               └────────────┬────────────┘
                            │
           ┌────────────────┼────────────────┐
@@ -44,6 +45,21 @@ in one direction: ESPN API -> parsing -> database -> ranking algorithm -> output
    └──────────────────────────────────────────┘
 ```
 
+## Multi-Sport Support
+
+The system supports college football and basketball through a `Sport` type in the
+ESPN package (`espn.CollegeFootball`, `espn.CollegeBasketball`). Each sport has:
+
+- **ESPN client configuration:** Different API URLs, group IDs, season types
+- **Database separation:** Shared tables use a `sport` column (`"cfb"` or `"cbb"`)
+- **Ranking constants:** Sport-dependent `requiredGames`, `yearsBack`, and MOV caps
+- **Division structure:** Football has FBS/FCS; basketball has D1 only
+- **JSON output paths:** Sport-prefixed (`cfb/ranking/...`, `cbb/ranking/...`)
+
+The `Updater` and `Ranker` structs each carry a sport identifier. The CLI
+exposes sport subcommands (`football`, `basketball`). The `schedule` command runs
+both sports in a single process with sport-appropriate cron schedules.
+
 ## Package Dependency Rules
 
 Dependencies flow **downward only**. Packages must not import from peers at the
@@ -51,7 +67,7 @@ same level or from `cmd/`.
 
 ```
 cmd/ranker   → config, database, ranking
-cmd/updater  → config, database, logger, updater, writer
+cmd/updater  → config, database, logger, updater, writer, espn
 cmd/migrate  → database
 
 updater      → database, espn, game, ranking, team, writer
@@ -90,33 +106,41 @@ type Updater struct {
     Logger *zap.SugaredLogger
     Writer writer.Writer
     ESPN   *espn.Client
+    Sport  espn.Sport
 }
 ```
 
 Responsible for: fetching games, updating the DB, computing rankings, and
 exporting JSON. Used by `cmd/updater` in both scheduled and on-demand modes.
+Each sport gets its own `Updater` instance with a sport-specific ESPN client.
 
 ### Ranker Struct
 
 ```go
 type Ranker struct {
-    DB   *gorm.DB
-    Year int64
-    Week int64
-    Fcs  bool
+    DB    *gorm.DB
+    Year  int64
+    Week  int64
+    Fcs   bool
+    Sport string  // "cfb" or "cbb"
 }
 ```
 
 Executes the ranking pipeline: `setup → record → srs → sos → finalRanking`.
-All computation happens in-memory after initial DB queries.
+All computation happens in-memory after initial DB queries. Sport-dependent
+constants (required games, years of history, MOV caps) are selected via
+`sportConfig()`.
 
 ### ESPN Client
 
 HTTP client backed by the `espn.Client` struct, which holds retry and
 rate-limit configuration (`MaxRetries`, `InitialBackoff`, `RequestTimeout`,
-`RateLimit`). Retries use exponential backoff capped at 30s. All ESPN
-functions are methods on `*Client`. URLs are package-level vars so tests can
-override them with a mock HTTP server.
+`RateLimit`). Retries use exponential backoff capped at 30s.
+
+Each client is bound to a sport via `NewClientForSport(sport)`, which sets
+per-client URLs for that sport's ESPN endpoints. The `NewClient()` constructor
+defaults to football and uses package-level URL vars (overridable in tests via
+`SetTestURLs`).
 
 ## Database
 
@@ -125,7 +149,9 @@ PostgreSQL (production) and SQLite (local development). Connection is determined
 by whether `DBParams` is nil (nil → SQLite).
 
 All models use composite primary keys for multi-dimensional lookups
-(team+year, game+team, etc.).
+(team+year, game+team, etc.). Shared tables (`games`, `team_names`,
+`team_seasons`, `team_week_results`) include a `sport` column with a default of
+`"cfb"`. The `team_seasons` and `team_week_results` primary keys include `sport`.
 
 ## Deployment
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,14 +105,14 @@ type Updater struct {
     DB     *gorm.DB
     Logger *zap.SugaredLogger
     Writer writer.Writer
-    ESPN   *espn.Client
-    Sport  espn.Sport
+    ESPN   espn.SportClient
 }
 ```
 
 Responsible for: fetching games, updating the DB, computing rankings, and
 exporting JSON. Used by `cmd/updater` in both scheduled and on-demand modes.
 Each sport gets its own `Updater` instance with a sport-specific ESPN client.
+The sport is derived from the `ESPN` client's `SportInfo()` method.
 
 ### Ranker Struct
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,19 @@ College sports computer ranking system written in Go. Collects game data from
 ESPN for football and basketball, computes rankings using a composite algorithm,
 and exports results to DigitalOcean Spaces.
 
+## Repo Responsibilities
+
+This repo is the **orchestration authority** for all cross-repo work. It owns:
+
+- Docker Compose configuration (backend + Postgres)
+- Database schema and all migrations
+- API contracts — field names, response shapes, HTTP semantics
+- Runtime behavior and business logic
+
+The sibling repo `stats-web` is a static site consumer. It has no authority
+over schema, contracts, or deployment orchestration. All API decisions are made
+here. See [docs/multi-repo-workflow.md](docs/multi-repo-workflow.md).
+
 ## Quick Reference
 
 - **Language:** Go 1.26
@@ -64,6 +77,45 @@ Key patterns:
 - `nolint` directives require both a specific linter and an explanation
   (`require-explanation: true`, `require-specific: true`).
 
+## Migration Rules
+
+- **Additive first.** New columns must be nullable or carry a DEFAULT. Never
+  add a NOT NULL column without a default to an existing table in a single
+  migration.
+- **No drops in the same migration that adds.** If replacing a column, the
+  drop is a separate migration after `stats-web` has stopped reading the old field.
+- **Destructive migrations require a rollback plan** documented in the PR body.
+- **Migrations are forward-only.** Write them as if rollback is unavailable. A
+  wrong migration is fixed by a new forward migration, not an edit.
+- **Test against populated data**, not just an empty schema.
+
+See [docs/migration-rules.md](docs/migration-rules.md) for full guidance.
+
+## Branching & PR Rules
+
+- **Never commit directly to `master`.** Always branch.
+- Branch naming: `<type>/<short-description>` — e.g., `feat/add-basketball-api`,
+  `fix/migration-null-column`.
+- One PR per feature slice. Scope PRs tightly.
+- PRs introducing a new or changed API contract must include the contract shape
+  in the PR description: field names, types, HTTP method, and path.
+- Do not merge if `docker compose up` fails or if tests/lint are red.
+- Backend PR merges before the corresponding `stats-web` PR is opened.
+
+## Anti-Patterns
+
+- **Do not negotiate API contracts in `stats-web`.** All API decisions are made
+  here. If the frontend surfaces a problem, fix it here.
+- **Do not add a frontend workaround for a backend bug.** Fix the backend.
+- **Do not add NOT NULL columns without defaults in a single migration.**
+- **Do not open a `stats-web` PR before the backend contract is finalized.**
+- **Do not duplicate these rules in `stats-web`.** That repo defers to this one.
+  Link to this file, do not copy it.
+- **Do not skip `docker compose up` validation.** A green stack is the minimum
+  bar for "done" on any backend feature.
+- **Do not introduce schema hacks** (nullable columns used as booleans, magic
+  sentinel strings) without immediately recording them in `docs/tech-debt.md`.
+
 ## Golden Rule: Keep Documentation Up to Date
 
 Any change that alters architecture, package dependencies, public interfaces,
@@ -84,3 +136,5 @@ discovering or resolving tech debt, update `docs/tech-debt.md`.
 - [docs/design-decisions.md](docs/design-decisions.md) — rationale for key choices
 - [docs/espn-api.md](docs/espn-api.md) — ESPN endpoints and data shapes
 - [docs/tech-debt.md](docs/tech-debt.md) — known issues and improvement areas
+- [docs/multi-repo-workflow.md](docs/multi-repo-workflow.md) — cross-repo feature process and `stats-web` coordination
+- [docs/migration-rules.md](docs/migration-rules.md) — database migration safety rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Key patterns:
   of the ranker CLI output (enforced via `forbidigo` lint).
 - Errors are propagated up — panics are only recovered at the scheduler level
   in `cmd/updater`.
-- ESPN API calls use `espn.Client.RateLimit` (default 200ms) between batch
+- ESPN API calls use `espn.Client.RateLimit` (default 500ms) between batch
   requests (in `game/`).
 - The HTTP client in `espn/request.go` retries with exponential backoff
   (`InitialBackoff * 2^attempt`, capped at 30s). Defaults: 5 retries, 1s initial backoff.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # stats-go
 
-College football computer ranking system written in Go. Collects game data from
-ESPN, computes rankings using a composite algorithm, and exports results to
-DigitalOcean Spaces.
+College sports computer ranking system written in Go. Collects game data from
+ESPN for football and basketball, computes rankings using a composite algorithm,
+and exports results to DigitalOcean Spaces.
 
 ## Quick Reference
 
@@ -38,11 +38,14 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the full dependency graph and design
 rationale.
 
 Key patterns:
+- **Multi-sport support** — Football (`cfb`) and basketball (`cbb`) via `espn.Sport` type
 - **Three independent CLI entry points** in `cmd/` — each wires its own deps
+- **Sport subcommands** — CLIs use `football`/`basketball` subcommands; `schedule` runs both
 - **Writer interface** (`internal/writer`) — pluggable output (DO Spaces vs local files)
-- **Updater struct** receives DB, Logger, Writer, and ESPN client via dependency injection
-- **ESPN package** is a pure HTTP client (`espn.Client` struct) with no DB dependency
-- **Ranking package** takes a `*gorm.DB` and computes everything in-memory
+- **Updater struct** receives DB, Logger, Writer, ESPN client, and Sport via dependency injection
+- **ESPN package** — per-client URLs via `NewClientForSport(sport)`, no DB dependency
+- **Ranking package** takes a `*gorm.DB` and sport, computes everything in-memory
+- **Sport column** on shared DB tables (`games`, `team_names`, `team_seasons`, `team_week_results`)
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# College Football Computer Ranking
+# College Sports Computer Ranking
 
 A Go application that pulls game data from the ESPN API, computes SRS/SOS
-composite rankings for college football teams, and exports results to
-DigitalOcean Spaces.
+composite rankings for college football and basketball teams, and exports
+results to DigitalOcean Spaces.
 
 ## Overview
 
@@ -13,7 +13,8 @@ The system consists of two CLI tools:
   computes rankings, and exports JSON to a CDN
 
 Rankings use a composite algorithm based on Simple Rating System (SRS) and
-Strength of Schedule (SOS), supporting both FBS and FCS divisions.
+Strength of Schedule (SOS). Football supports both FBS and FCS divisions;
+basketball ranks D1 teams.
 
 ## Getting Started
 
@@ -42,48 +43,59 @@ Set in `.env` (see `.env-sample` for the full list):
 
 ### Ranker
 
-Generate and print a ranking:
+Generate and print a ranking. The ranker uses sport subcommands (`football`,
+`basketball`):
 
 ```sh
-make ranker                      # current season, all teams
-make ranker OPTS="-t 25"         # top 25
-make ranker OPTS="-y 2024 -w 12" # specific year and week
-make ranker OPTS="-f"            # rank FCS instead of FBS
+make ranker OPTS="football"                # current football season, all teams
+make ranker OPTS="football -t 25"          # top 25 football
+make ranker OPTS="football -y 2024 -w 12"  # specific year and week
+make ranker OPTS="football -f"             # rank FCS instead of FBS
+make ranker OPTS="basketball"              # current basketball season, D1
+make ranker OPTS="basketball -t 25"        # top 25 basketball
 ```
 
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `-y` | int | most recent | Year to rank |
-| `-w` | int | most recent | Week of the season |
-| `-f` | bool | false | Rank FCS instead of FBS |
-| `-t` | int | all | Print only the top N teams |
-| `-r` | bool | false | Print SRS ratings instead of full ranking |
+| Subcommand | Flag | Type | Default | Description |
+|------------|------|------|---------|-------------|
+| `football` | `-y` | int | most recent | Year to rank |
+| | `-w` | int | most recent | Week of the season |
+| | `-f` | bool | false | Rank FCS instead of FBS |
+| | `-t` | int | all | Print only the top N teams |
+| | `-r` | bool | false | Print SRS ratings instead of full ranking |
+| `basketball` | `-y` | int | most recent | Year to rank |
+| | `-w` | int | most recent | Week of the season |
+| | `-t` | int | all | Print only the top N teams |
+| | `-r` | bool | false | Print SRS ratings instead of full ranking |
 
 ### Updater
 
-Run one-off operations or start the scheduled service:
+Run one-off operations or start the scheduled service. One-shot commands are
+nested under sport subcommands (`football`, `basketball`). The `schedule`
+command runs both sports:
 
 ```sh
-make updater OPTS="schedule"              # run as scheduled service
-make updater OPTS="games"                 # update current week's games
-make updater OPTS="games --all"           # update all games for current year
-make updater OPTS="games --single 12345"  # force-update a single game by ID
-make updater OPTS="ranking"               # update current season rankings
-make updater OPTS="ranking --all"         # update all rankings
-make updater OPTS="teams"                 # update team info
-make updater OPTS="season"               # update season info
-make updater OPTS="json"                  # rewrite current season JSON
-make updater OPTS="json --all"            # rewrite all JSON
+make updater OPTS="schedule"                        # run scheduled service (both sports)
+make updater OPTS="football games"                  # update current week's football games
+make updater OPTS="football games --all"            # update all football games for current year
+make updater OPTS="football games --single 12345"   # force-update a single game by ID
+make updater OPTS="football ranking"                # update current football rankings
+make updater OPTS="football ranking --all"          # update all football rankings
+make updater OPTS="football teams"                  # update football team info
+make updater OPTS="football season"                 # update football season info
+make updater OPTS="football json"                   # rewrite current football JSON
+make updater OPTS="football json --all"             # rewrite all football JSON
+make updater OPTS="basketball games --all"          # update all basketball games
+make updater OPTS="basketball ranking"              # update basketball rankings
 ```
 
-| Command | Flags | Description |
-|---------|-------|-------------|
-| `schedule` | | Run as a scheduled service (polls every 5 min Aug-Jan) |
-| `games` | `--all`, `--single <id>` | Update games (current week by default) |
-| `ranking` | `--all` | Update rankings (current season by default) |
-| `teams` | | Update team info from ESPN |
-| `season` | | Update season info |
-| `json` | `--all` | Rewrite JSON output (current season by default) |
+| Subcommand | Command | Flags | Description |
+|------------|---------|-------|-------------|
+| `schedule` | | | Run as scheduled service (both sports) |
+| `football` / `basketball` | `games` | `--all`, `--single <id>` | Update games (current week by default) |
+| | `ranking` | `--all` | Update rankings (current season by default) |
+| | `teams` | | Update team info from ESPN |
+| | `season` | | Update season info |
+| | `json` | `--all` | Rewrite JSON output (current season by default) |
 
 ## Development
 
@@ -124,7 +136,7 @@ make local-deploy     # build and run via docker compose
 ```
 
 In production, the container runs `updater schedule`, which polls for completed
-games every 5 minutes during the season (August through January).
+games during each sport's season (football: Aug–Jan, basketball: Nov–Apr).
 
 ## CI/CD
 

--- a/cmd/ranker/main.go
+++ b/cmd/ranker/main.go
@@ -64,6 +64,9 @@ func sportRankCmd(db *gorm.DB, sport string, hasFCS bool) *cobra.Command {
 			start := time.Now()
 			div, err := r.CalculateRanking()
 			duration := time.Since(start)
+			if err != nil {
+				return err
+			}
 
 			// sanitize input
 			if top <= 0 || top > len(div) {
@@ -75,7 +78,6 @@ func sportRankCmd(db *gorm.DB, sport string, hasFCS bool) *cobra.Command {
 			} else {
 				r.PrintRankings(div, top)
 			}
-			fmt.Println(err)      //nolint:forbidigo // allow
 			fmt.Println(duration) //nolint:forbidigo // allow
 			return nil
 		},

--- a/cmd/ranker/main.go
+++ b/cmd/ranker/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"time"
+
+	"github.com/spf13/cobra"
+
+	"gorm.io/gorm"
 
 	"github.com/robby-barton/stats-go/internal/config"
 	"github.com/robby-barton/stats-go/internal/database"
@@ -11,48 +14,80 @@ import (
 )
 
 func main() {
-	// args
-	var year, week int64
-	var top int
-	var fcs, rating bool
-	flag.Int64Var(&year, "y", 0, "ranking year")
-	flag.Int64Var(&week, "w", 0, "ranking week")
-	flag.IntVar(&top, "t", 0, "print top N teams")
-	flag.BoolVar(&fcs, "f", false, "rank FCS")
-	flag.BoolVar(&rating, "r", false, "print rating")
-	flag.Parse()
-
 	cfg := config.SetupConfig()
 
 	db, err := database.NewDatabase(cfg.DBParams)
 	if err != nil {
 		panic(err)
 	}
-
 	sqlDB, _ := db.DB()
 	defer sqlDB.Close()
 
-	r := ranking.Ranker{
-		DB:   db,
-		Year: year,
-		Week: week,
-		Fcs:  fcs,
+	rootCmd := &cobra.Command{
+		Use:   "ranker",
+		Short: "College sports computer ranking calculator",
+	}
+	rootCmd.SilenceUsage = true
+
+	footballCmd := sportRankCmd(db, "cfb", true)
+	basketballCmd := sportRankCmd(db, "cbb", false)
+
+	rootCmd.AddCommand(footballCmd, basketballCmd)
+
+	rootCmd.Execute() //nolint:errcheck // cobra prints errors; exit code unused
+}
+
+func sportRankCmd(db *gorm.DB, sport string, hasFCS bool) *cobra.Command {
+	var year, week int64
+	var top int
+	var fcs, rating bool
+
+	use := "football"
+	short := "Calculate college football rankings"
+	if sport == "cbb" {
+		use = "basketball"
+		short = "Calculate college basketball rankings"
 	}
 
-	start := time.Now()
-	div, err := r.CalculateRanking()
-	duration := time.Since(start)
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			r := ranking.Ranker{
+				DB:    db,
+				Year:  year,
+				Week:  week,
+				Fcs:   fcs,
+				Sport: sport,
+			}
 
-	// sanitize input
-	if top <= 0 || top > len(div) {
-		top = len(div)
+			start := time.Now()
+			div, err := r.CalculateRanking()
+			duration := time.Since(start)
+
+			// sanitize input
+			if top <= 0 || top > len(div) {
+				top = len(div)
+			}
+
+			if rating {
+				r.PrintSRS(div, top)
+			} else {
+				r.PrintRankings(div, top)
+			}
+			fmt.Println(err)      //nolint:forbidigo // allow
+			fmt.Println(duration) //nolint:forbidigo // allow
+			return nil
+		},
 	}
 
-	if rating {
-		r.PrintSRS(div, top)
-	} else {
-		r.PrintRankings(div, top)
+	cmd.Flags().Int64VarP(&year, "year", "y", 0, "ranking year")
+	cmd.Flags().Int64VarP(&week, "week", "w", 0, "ranking week")
+	cmd.Flags().IntVarP(&top, "top", "t", 0, "print top N teams")
+	cmd.Flags().BoolVarP(&rating, "rating", "r", false, "print rating")
+	if hasFCS {
+		cmd.Flags().BoolVarP(&fcs, "fcs", "f", false, "rank FCS")
 	}
-	fmt.Println(err)      //nolint:forbidigo // allow
-	fmt.Println(duration) //nolint:forbidigo // allow
+
+	return cmd
 }

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -68,6 +68,122 @@ func newUpdater(
 	}
 }
 
+// sportSchedule holds the cron expressions for a sport's scheduled jobs.
+type sportSchedule struct {
+	Name          string // human-readable label for log messages
+	GamesCron     string // completed games poll
+	TeamInfoCron  string // team metadata refresh
+	NewSeasonCron string // season initialization
+}
+
+// registerJobs adds the three cron jobs for a sport to the scheduler and
+// returns a stop function that shuts down the ranking-update goroutine.
+func (ss sportSchedule) registerJobs(
+	s gocron.Scheduler,
+	log *zap.SugaredLogger,
+	cfg *config.Config,
+	u updater.Updater,
+) func() {
+	update := make(chan bool, 1)
+	stop := make(chan bool, 1)
+
+	go func() {
+		for {
+			select {
+			case <-update:
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							log.Errorf("%s panic caught: %s", ss.Name, r)
+						}
+					}()
+
+					if err := u.UpdateRecentRankings(); err != nil {
+						log.Error(err)
+						return
+					}
+					log.Infof("%s rankings updated", ss.Name)
+
+					if !cfg.Local {
+						if err := u.UpdateRecentJSON(); err != nil {
+							log.Error(err)
+						}
+					}
+				}()
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	// Completed games poll
+	if _, err := s.NewJob(gocron.CronJob(ss.GamesCron, false), gocron.NewTask(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Errorf("%s panic caught: %s", ss.Name, r)
+			}
+		}()
+
+		addedGames, err := u.UpdateCurrentWeek()
+		log.Infof("%s: added %d games: %v", ss.Name, len(addedGames), addedGames)
+		if err != nil {
+			log.Error(err)
+		} else if len(addedGames) > 0 {
+			update <- true
+		}
+	})); err != nil {
+		panic(err)
+	}
+
+	// Team info refresh
+	if _, err := s.NewJob(gocron.CronJob(ss.TeamInfoCron, false), gocron.NewTask(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Errorf("%s panic caught: %s", ss.Name, r)
+			}
+		}()
+
+		addedTeams, err := u.UpdateTeamInfo()
+		if err != nil {
+			log.Error(err)
+			return
+		}
+
+		log.Infof("%s: updated %d teams", ss.Name, addedTeams)
+		if !cfg.Local {
+			if err := u.UpdateTeamsJSON(nil); err != nil {
+				log.Error(err)
+			}
+			if err := u.Writer.PurgeCache(context.Background()); err != nil {
+				log.Error(err)
+			}
+		}
+	})); err != nil {
+		panic(err)
+	}
+
+	// New season initialization
+	if _, err := s.NewJob(gocron.CronJob(ss.NewSeasonCron, false), gocron.NewTask(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Errorf("%s panic caught: %s", ss.Name, r)
+			}
+		}()
+
+		addedSeasons, err := u.UpdateTeamSeasons(false)
+		log.Infof("%s: added %d seasons", ss.Name, addedSeasons)
+		if err != nil {
+			log.Error(err)
+		} else if addedSeasons > 0 {
+			update <- true
+		}
+	})); err != nil {
+		panic(err)
+	}
+
+	return func() { stop <- true }
+}
+
 func scheduleCommand(
 	log *zap.SugaredLogger,
 	cfg *config.Config,
@@ -78,212 +194,40 @@ func scheduleCommand(
 		Use:   "schedule",
 		Short: "Run the scheduled updater for all sports",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			cfb := newUpdater(log, db, w, espn.CollegeFootball)
-			cbb := newUpdater(log, db, w, espn.CollegeBasketball)
-
 			s, err := gocron.NewScheduler(gocron.WithLocation(time.Local))
 			if err != nil {
 				panic(err)
 			}
 
-			// --- Football update channel ---
-			cfbUpdate := make(chan bool, 1)
-			cfbStop := make(chan bool, 1)
-			go func() {
-				for {
-					select {
-					case <-cfbUpdate:
-						func() {
-							defer func() {
-								if r := recover(); r != nil {
-									log.Errorf("football panic caught: %s", r)
-								}
-							}()
-
-							if err := cfb.UpdateRecentRankings(); err != nil {
-								log.Error(err)
-								return
-							}
-							log.Info("football rankings updated")
-
-							if !cfg.Local {
-								if err := cfb.UpdateRecentJSON(); err != nil {
-									log.Error(err)
-								}
-							}
-						}()
-					case <-cfbStop:
-						return
-					}
-				}
-			}()
-
-			// --- Basketball update channel ---
-			cbbUpdate := make(chan bool, 1)
-			cbbStop := make(chan bool, 1)
-			go func() {
-				for {
-					select {
-					case <-cbbUpdate:
-						func() {
-							defer func() {
-								if r := recover(); r != nil {
-									log.Errorf("basketball panic caught: %s", r)
-								}
-							}()
-
-							if err := cbb.UpdateRecentRankings(); err != nil {
-								log.Error(err)
-								return
-							}
-							log.Info("basketball rankings updated")
-
-							if !cfg.Local {
-								if err := cbb.UpdateRecentJSON(); err != nil {
-									log.Error(err)
-								}
-							}
-						}()
-					case <-cbbStop:
-						return
-					}
-				}
-			}()
-
-			// Football: completed games every 5 min, Aug–Jan
-			_, err = s.NewJob(gocron.CronJob("*/5 * * 1,8-12 *", false), gocron.NewTask(func() {
-				defer func() {
-					if r := recover(); r != nil {
-						log.Errorf("football panic caught: %s", r)
-					}
-				}()
-
-				addedGames, err := cfb.UpdateCurrentWeek()
-				log.Infof("football: added %d games: %v", len(addedGames), addedGames)
-				if err != nil {
-					log.Error(err)
-				} else if len(addedGames) > 0 {
-					cfbUpdate <- true
-				}
-			}))
-			if err != nil {
-				panic(err)
+			sports := []struct {
+				schedule sportSchedule
+				sport    espn.Sport
+			}{
+				{
+					schedule: sportSchedule{
+						Name:          "football",
+						GamesCron:     "*/5 * * 1,8-12 *",
+						TeamInfoCron:  "0 5 * 1,8-12 0",
+						NewSeasonCron: "0 6 10 8 *",
+					},
+					sport: espn.CollegeFootball,
+				},
+				{
+					schedule: sportSchedule{
+						Name:          "basketball",
+						GamesCron:     "*/5 * * 1-4,11-12 *",
+						TeamInfoCron:  "0 5 * 1-4,11-12 0",
+						NewSeasonCron: "0 6 1 11 *",
+					},
+					sport: espn.CollegeBasketball,
+				},
 			}
 
-			// Football: team info, 5 am Sunday Aug–Jan
-			_, err = s.NewJob(gocron.CronJob("0 5 * 1,8-12 0", false), gocron.NewTask(func() {
-				defer func() {
-					if r := recover(); r != nil {
-						log.Errorf("football panic caught: %s", r)
-					}
-				}()
-
-				addedTeams, err := cfb.UpdateTeamInfo()
-				if err != nil {
-					log.Error(err)
-					return
-				}
-
-				log.Infof("football: updated %d teams", addedTeams)
-				if !cfg.Local {
-					if err := cfb.UpdateTeamsJSON(nil); err != nil {
-						log.Error(err)
-					}
-					if err := cfb.Writer.PurgeCache(context.Background()); err != nil {
-						log.Error(err)
-					}
-				}
-			}))
-			if err != nil {
-				panic(err)
-			}
-
-			// Football: new season, 6 am Aug 10
-			_, err = s.NewJob(gocron.CronJob("0 6 10 8 *", false), gocron.NewTask(func() {
-				defer func() {
-					if r := recover(); r != nil {
-						log.Errorf("football panic caught: %s", r)
-					}
-				}()
-
-				addedSeasons, err := cfb.UpdateTeamSeasons(false)
-				log.Infof("football: added %d seasons", addedSeasons)
-				if err != nil {
-					log.Error(err)
-				} else if addedSeasons > 0 {
-					cfbUpdate <- true
-				}
-			}))
-			if err != nil {
-				panic(err)
-			}
-
-			// Basketball: completed games every 5 min, Nov–Apr
-			_, err = s.NewJob(gocron.CronJob("*/5 * * 1-4,11-12 *", false), gocron.NewTask(func() {
-				defer func() {
-					if r := recover(); r != nil {
-						log.Errorf("basketball panic caught: %s", r)
-					}
-				}()
-
-				addedGames, err := cbb.UpdateCurrentWeek()
-				log.Infof("basketball: added %d games: %v", len(addedGames), addedGames)
-				if err != nil {
-					log.Error(err)
-				} else if len(addedGames) > 0 {
-					cbbUpdate <- true
-				}
-			}))
-			if err != nil {
-				panic(err)
-			}
-
-			// Basketball: team info, 5 am Sunday Nov–Apr
-			_, err = s.NewJob(gocron.CronJob("0 5 * 1-4,11-12 0", false), gocron.NewTask(func() {
-				defer func() {
-					if r := recover(); r != nil {
-						log.Errorf("basketball panic caught: %s", r)
-					}
-				}()
-
-				addedTeams, err := cbb.UpdateTeamInfo()
-				if err != nil {
-					log.Error(err)
-					return
-				}
-
-				log.Infof("basketball: updated %d teams", addedTeams)
-				if !cfg.Local {
-					if err := cbb.UpdateTeamsJSON(nil); err != nil {
-						log.Error(err)
-					}
-					if err := cbb.Writer.PurgeCache(context.Background()); err != nil {
-						log.Error(err)
-					}
-				}
-			}))
-			if err != nil {
-				panic(err)
-			}
-
-			// Basketball: new season, 6 am Nov 1
-			_, err = s.NewJob(gocron.CronJob("0 6 1 11 *", false), gocron.NewTask(func() {
-				defer func() {
-					if r := recover(); r != nil {
-						log.Errorf("basketball panic caught: %s", r)
-					}
-				}()
-
-				addedSeasons, err := cbb.UpdateTeamSeasons(false)
-				log.Infof("basketball: added %d seasons", addedSeasons)
-				if err != nil {
-					log.Error(err)
-				} else if addedSeasons > 0 {
-					cbbUpdate <- true
-				}
-			}))
-			if err != nil {
-				panic(err)
+			var stopFuncs []func()
+			for _, sp := range sports {
+				u := newUpdater(log, db, w, sp.sport)
+				stopFn := sp.schedule.registerJobs(s, log, cfg, u)
+				stopFuncs = append(stopFuncs, stopFn)
 			}
 
 			s.Start()
@@ -295,8 +239,9 @@ func scheduleCommand(
 			if err := s.Shutdown(); err != nil {
 				log.Error(err)
 			}
-			cfbStop <- true
-			cbbStop <- true
+			for _, fn := range stopFuncs {
+				fn()
+			}
 
 			return nil
 		},

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -64,7 +64,6 @@ func newUpdater(
 		Logger: log,
 		Writer: w,
 		ESPN:   espn.NewClientForSport(sport),
-		Sport:  sport,
 	}
 }
 

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/go-co-op/gocron/v2"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
 
 	"github.com/robby-barton/stats-go/internal/config"
 	"github.com/robby-barton/stats-go/internal/database"
@@ -35,105 +37,159 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	espnClient := espn.NewClient()
-	u := updater.Updater{
-		DB:     db,
-		Logger: log,
-		Writer: doWriter,
-		ESPN:   espnClient,
-	}
 
 	rootCmd := &cobra.Command{
 		Use:   "updater",
-		Short: "College football data updater",
+		Short: "College sports data updater",
 	}
 	rootCmd.SilenceUsage = true
 
-	scheduleCmd := &cobra.Command{
+	scheduleCmd := scheduleCommand(log, cfg, db, doWriter)
+	footballCmd := sportCommand(log, db, doWriter, espn.CollegeFootball)
+	basketballCmd := sportCommand(log, db, doWriter, espn.CollegeBasketball)
+
+	rootCmd.AddCommand(scheduleCmd, footballCmd, basketballCmd)
+
+	rootCmd.Execute() //nolint:errcheck // cobra prints errors; exit code unused
+}
+
+func newUpdater(
+	log *zap.SugaredLogger,
+	db *gorm.DB,
+	w writer.Writer,
+	sport espn.Sport,
+) updater.Updater {
+	return updater.Updater{
+		DB:     db,
+		Logger: log,
+		Writer: w,
+		ESPN:   espn.NewClientForSport(sport),
+		Sport:  sport,
+	}
+}
+
+func scheduleCommand(
+	log *zap.SugaredLogger,
+	cfg *config.Config,
+	db *gorm.DB,
+	w writer.Writer,
+) *cobra.Command {
+	return &cobra.Command{
 		Use:   "schedule",
-		Short: "Run the scheduled updater",
+		Short: "Run the scheduled updater for all sports",
 		RunE: func(_ *cobra.Command, _ []string) error {
+			cfb := newUpdater(log, db, w, espn.CollegeFootball)
+			cbb := newUpdater(log, db, w, espn.CollegeBasketball)
+
 			s, err := gocron.NewScheduler(gocron.WithLocation(time.Local))
 			if err != nil {
 				panic(err)
 			}
 
-			update := make(chan bool, 1)
-			stop := make(chan bool, 1)
+			// --- Football update channel ---
+			cfbUpdate := make(chan bool, 1)
+			cfbStop := make(chan bool, 1)
 			go func() {
 				for {
 					select {
-					case <-update:
+					case <-cfbUpdate:
 						func() {
 							defer func() {
 								if r := recover(); r != nil {
-									log.Errorf("panic caught: %s", r)
+									log.Errorf("football panic caught: %s", r)
 								}
 							}()
 
-							if err := u.UpdateRecentRankings(); err != nil {
+							if err := cfb.UpdateRecentRankings(); err != nil {
 								log.Error(err)
 								return
 							}
-							log.Info("rankings updated")
+							log.Info("football rankings updated")
 
 							if !cfg.Local {
-								if err := u.UpdateRecentJSON(); err != nil {
+								if err := cfb.UpdateRecentJSON(); err != nil {
 									log.Error(err)
 								}
 							}
 						}()
-					case <-stop:
+					case <-cfbStop:
 						return
 					}
 				}
 			}()
 
-			// Update completed games
-			// every 5 minutes from August through January
+			// --- Basketball update channel ---
+			cbbUpdate := make(chan bool, 1)
+			cbbStop := make(chan bool, 1)
+			go func() {
+				for {
+					select {
+					case <-cbbUpdate:
+						func() {
+							defer func() {
+								if r := recover(); r != nil {
+									log.Errorf("basketball panic caught: %s", r)
+								}
+							}()
+
+							if err := cbb.UpdateRecentRankings(); err != nil {
+								log.Error(err)
+								return
+							}
+							log.Info("basketball rankings updated")
+
+							if !cfg.Local {
+								if err := cbb.UpdateRecentJSON(); err != nil {
+									log.Error(err)
+								}
+							}
+						}()
+					case <-cbbStop:
+						return
+					}
+				}
+			}()
+
+			// Football: completed games every 5 min, Aug–Jan
 			_, err = s.NewJob(gocron.CronJob("*/5 * * 1,8-12 *", false), gocron.NewTask(func() {
 				defer func() {
 					if r := recover(); r != nil {
-						log.Errorf("panic caught: %s", r)
+						log.Errorf("football panic caught: %s", r)
 					}
 				}()
 
-				var addedGames []int64
-				addedGames, err = u.UpdateCurrentWeek()
-
-				log.Infof("Added %d games: %v", len(addedGames), addedGames)
+				addedGames, err := cfb.UpdateCurrentWeek()
+				log.Infof("football: added %d games: %v", len(addedGames), addedGames)
 				if err != nil {
 					log.Error(err)
 				} else if len(addedGames) > 0 {
-					update <- true
+					cfbUpdate <- true
 				}
 			}))
 			if err != nil {
 				panic(err)
 			}
 
-			// Update team info
-			// 5 am Sunday from August through January
+			// Football: team info, 5 am Sunday Aug–Jan
 			_, err = s.NewJob(gocron.CronJob("0 5 * 1,8-12 0", false), gocron.NewTask(func() {
 				defer func() {
 					if r := recover(); r != nil {
-						log.Errorf("panic caught: %s", r)
+						log.Errorf("football panic caught: %s", r)
 					}
 				}()
 
-				var addedTeams int
-				addedTeams, err = u.UpdateTeamInfo()
+				addedTeams, err := cfb.UpdateTeamInfo()
 				if err != nil {
 					log.Error(err)
 					return
 				}
 
-				log.Infof("Updated %d teams", addedTeams)
+				log.Infof("football: updated %d teams", addedTeams)
 				if !cfg.Local {
-					if err := u.UpdateTeamsJSON(nil); err != nil {
+					if err := cfb.UpdateTeamsJSON(nil); err != nil {
 						log.Error(err)
 					}
-					if err := u.Writer.PurgeCache(context.Background()); err != nil {
+					if err := cfb.Writer.PurgeCache(context.Background()); err != nil {
 						log.Error(err)
 					}
 				}
@@ -142,23 +198,88 @@ func main() {
 				panic(err)
 			}
 
-			// Add new season
-			// 6 am on August 10th
+			// Football: new season, 6 am Aug 10
 			_, err = s.NewJob(gocron.CronJob("0 6 10 8 *", false), gocron.NewTask(func() {
 				defer func() {
 					if r := recover(); r != nil {
-						log.Errorf("panic caught: %s", r)
+						log.Errorf("football panic caught: %s", r)
 					}
 				}()
 
-				var addedSeasons int
-				addedSeasons, err = u.UpdateTeamSeasons(false)
-
-				log.Infof("Added %d seasons", addedSeasons)
+				addedSeasons, err := cfb.UpdateTeamSeasons(false)
+				log.Infof("football: added %d seasons", addedSeasons)
 				if err != nil {
 					log.Error(err)
 				} else if addedSeasons > 0 {
-					update <- true
+					cfbUpdate <- true
+				}
+			}))
+			if err != nil {
+				panic(err)
+			}
+
+			// Basketball: completed games every 5 min, Nov–Apr
+			_, err = s.NewJob(gocron.CronJob("*/5 * * 1-4,11-12 *", false), gocron.NewTask(func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Errorf("basketball panic caught: %s", r)
+					}
+				}()
+
+				addedGames, err := cbb.UpdateCurrentWeek()
+				log.Infof("basketball: added %d games: %v", len(addedGames), addedGames)
+				if err != nil {
+					log.Error(err)
+				} else if len(addedGames) > 0 {
+					cbbUpdate <- true
+				}
+			}))
+			if err != nil {
+				panic(err)
+			}
+
+			// Basketball: team info, 5 am Sunday Nov–Apr
+			_, err = s.NewJob(gocron.CronJob("0 5 * 1-4,11-12 0", false), gocron.NewTask(func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Errorf("basketball panic caught: %s", r)
+					}
+				}()
+
+				addedTeams, err := cbb.UpdateTeamInfo()
+				if err != nil {
+					log.Error(err)
+					return
+				}
+
+				log.Infof("basketball: updated %d teams", addedTeams)
+				if !cfg.Local {
+					if err := cbb.UpdateTeamsJSON(nil); err != nil {
+						log.Error(err)
+					}
+					if err := cbb.Writer.PurgeCache(context.Background()); err != nil {
+						log.Error(err)
+					}
+				}
+			}))
+			if err != nil {
+				panic(err)
+			}
+
+			// Basketball: new season, 6 am Nov 1
+			_, err = s.NewJob(gocron.CronJob("0 6 1 11 *", false), gocron.NewTask(func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Errorf("basketball panic caught: %s", r)
+					}
+				}()
+
+				addedSeasons, err := cbb.UpdateTeamSeasons(false)
+				log.Infof("basketball: added %d seasons", addedSeasons)
+				if err != nil {
+					log.Error(err)
+				} else if addedSeasons > 0 {
+					cbbUpdate <- true
 				}
 			}))
 			if err != nil {
@@ -174,10 +295,32 @@ func main() {
 			if err := s.Shutdown(); err != nil {
 				log.Error(err)
 			}
-			stop <- true
+			cfbStop <- true
+			cbbStop <- true
 
 			return nil
 		},
+	}
+}
+
+func sportCommand(
+	log *zap.SugaredLogger,
+	db *gorm.DB,
+	w writer.Writer,
+	sport espn.Sport,
+) *cobra.Command {
+	u := newUpdater(log, db, w, sport)
+
+	use := "football"
+	short := "College football one-shot commands"
+	if sport == espn.CollegeBasketball {
+		use = "basketball"
+		short = "College basketball one-shot commands"
+	}
+
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
 	}
 
 	var gamesAll bool
@@ -281,7 +424,7 @@ func main() {
 	}
 	jsonCmd.Flags().BoolVar(&jsonAll, "all", false, "rewrite all JSON")
 
-	rootCmd.AddCommand(scheduleCmd, gamesCmd, rankingCmd, teamsCmd, seasonCmd, jsonCmd)
+	cmd.AddCommand(gamesCmd, rankingCmd, teamsCmd, seasonCmd, jsonCmd)
 
-	rootCmd.Execute() //nolint:errcheck // cobra prints errors; exit code unused
+	return cmd
 }

--- a/db/migration_add_sport.sql
+++ b/db/migration_add_sport.sql
@@ -1,0 +1,27 @@
+-- Migration: Add sport column to support multiple sports (basketball + football)
+-- Run this against an existing PostgreSQL database before deploying the multi-sport code.
+-- All existing data is assumed to be college football (cfb).
+
+BEGIN;
+
+-- 1. Add sport column to games
+ALTER TABLE games ADD COLUMN IF NOT EXISTS sport text DEFAULT 'cfb';
+UPDATE games SET sport = 'cfb' WHERE sport IS NULL;
+
+-- 2. Add sport column to team_names
+ALTER TABLE team_names ADD COLUMN IF NOT EXISTS sport text DEFAULT 'cfb';
+UPDATE team_names SET sport = 'cfb' WHERE sport IS NULL;
+
+-- 3. Add sport column to team_seasons and update PK
+ALTER TABLE team_seasons ADD COLUMN IF NOT EXISTS sport text DEFAULT 'cfb';
+UPDATE team_seasons SET sport = 'cfb' WHERE sport IS NULL;
+ALTER TABLE team_seasons DROP CONSTRAINT IF EXISTS team_season_pkey;
+ALTER TABLE team_seasons ADD CONSTRAINT team_season_pkey PRIMARY KEY (team_id, year, sport);
+
+-- 4. Add sport column to team_week_results and update PK
+ALTER TABLE team_week_results ADD COLUMN IF NOT EXISTS sport text DEFAULT 'cfb' NOT NULL;
+UPDATE team_week_results SET sport = 'cfb' WHERE sport = 'cfb'; -- no-op but ensures NOT NULL is safe
+ALTER TABLE team_week_results DROP CONSTRAINT IF EXISTS team_week_result_pkey;
+ALTER TABLE team_week_results ADD CONSTRAINT team_week_result_pkey PRIMARY KEY (team_id, year, week, postseason, sport);
+
+COMMIT;

--- a/db/migration_add_sport.sql
+++ b/db/migration_add_sport.sql
@@ -8,9 +8,11 @@ BEGIN;
 ALTER TABLE games ADD COLUMN IF NOT EXISTS sport text DEFAULT 'cfb';
 UPDATE games SET sport = 'cfb' WHERE sport IS NULL;
 
--- 2. Add sport column to team_names
+-- 2. Add sport column to team_names and update PK
 ALTER TABLE team_names ADD COLUMN IF NOT EXISTS sport text DEFAULT 'cfb';
 UPDATE team_names SET sport = 'cfb' WHERE sport IS NULL;
+ALTER TABLE team_names DROP CONSTRAINT IF EXISTS team_name_pkey;
+ALTER TABLE team_names ADD CONSTRAINT team_name_pkey PRIMARY KEY (team_id, sport);
 
 -- 3. Add sport column to team_seasons and update PK
 ALTER TABLE team_seasons ADD COLUMN IF NOT EXISTS sport text DEFAULT 'cfb';

--- a/db/schema-sqlite.sql
+++ b/db/schema-sqlite.sql
@@ -39,6 +39,7 @@ CREATE TABLE games (
     game_id integer NOT NULL,
     neutral boolean DEFAULT false,
     conf_game boolean DEFAULT false,
+    sport text DEFAULT 'cfb',
     season integer DEFAULT 0,
     week integer DEFAULT 0,
     postseason integer DEFAULT 0,
@@ -214,6 +215,7 @@ CREATE TABLE team_game_stats (
 CREATE TABLE team_names (
     team_id integer NOT NULL,
     name text NOT NULL,
+    sport text DEFAULT 'cfb',
     flair text,
     abbreviation text,
     alt_color text,
@@ -234,10 +236,11 @@ CREATE TABLE team_names (
 CREATE TABLE team_seasons (
     team_id integer NOT NULL,
     year integer NOT NULL,
+    sport text DEFAULT 'cfb',
     fbs integer DEFAULT 0,
     power_five integer DEFAULT 0,
     conf text,
-	PRIMARY KEY (team_id, year)
+	PRIMARY KEY (team_id, year, sport)
 );
 
 
@@ -246,6 +249,7 @@ CREATE TABLE team_week_results (
     year integer NOT NULL,
     week integer NOT NULL,
     postseason integer DEFAULT 0 NOT NULL,
+    sport text DEFAULT 'cfb' NOT NULL,
     final_rank integer DEFAULT 0,
     final_raw real DEFAULT 0,
     wins integer DEFAULT 0,
@@ -258,7 +262,7 @@ CREATE TABLE team_week_results (
     conf text,
     sol_rank integer DEFAULT 0,
     ties integer DEFAULT 0,
-	PRIMARY KEY (team_id, year, week, postseason)
+	PRIMARY KEY (team_id, year, week, postseason, sport)
 );
 
 

--- a/db/schema-sqlite.sql
+++ b/db/schema-sqlite.sql
@@ -229,7 +229,7 @@ CREATE TABLE team_names (
     nickname text,
     short_display_name text,
     slug text,
-	PRIMARY KEY (team_id)
+	PRIMARY KEY (team_id, sport)
 );
 
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -501,7 +501,7 @@ ALTER TABLE ONLY public.team_game_stats
 --
 
 ALTER TABLE ONLY public.team_names
-    ADD CONSTRAINT team_name_pkey PRIMARY KEY (team_id);
+    ADD CONSTRAINT team_name_pkey PRIMARY KEY (team_id, sport);
 
 
 --

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -87,6 +87,7 @@ CREATE TABLE public.games (
     game_id integer NOT NULL,
     neutral boolean DEFAULT false,
     conf_game boolean DEFAULT false,
+    sport text DEFAULT 'cfb',
     season integer DEFAULT 0,
     week integer DEFAULT 0,
     postseason integer DEFAULT 0,
@@ -313,6 +314,7 @@ ALTER TABLE public.team_game_stats OWNER TO stats;
 CREATE TABLE public.team_names (
     team_id integer NOT NULL,
     name text NOT NULL,
+    sport text DEFAULT 'cfb',
     flair text,
     abbreviation text,
     alt_color text,
@@ -338,6 +340,7 @@ ALTER TABLE public.team_names OWNER TO stats;
 CREATE TABLE public.team_seasons (
     team_id integer NOT NULL,
     year integer NOT NULL,
+    sport text DEFAULT 'cfb',
     fbs integer DEFAULT 0,
     power_five integer DEFAULT 0,
     conf text
@@ -355,6 +358,7 @@ CREATE TABLE public.team_week_results (
     year integer NOT NULL,
     week integer NOT NULL,
     postseason integer DEFAULT 0 NOT NULL,
+    sport text DEFAULT 'cfb' NOT NULL,
     final_rank integer DEFAULT 0,
     final_raw real DEFAULT 0,
     wins integer DEFAULT 0,
@@ -505,7 +509,7 @@ ALTER TABLE ONLY public.team_names
 --
 
 ALTER TABLE ONLY public.team_seasons
-    ADD CONSTRAINT team_season_pkey PRIMARY KEY (team_id, year);
+    ADD CONSTRAINT team_season_pkey PRIMARY KEY (team_id, year, sport);
 
 
 --
@@ -513,7 +517,7 @@ ALTER TABLE ONLY public.team_seasons
 --
 
 ALTER TABLE ONLY public.team_week_results
-    ADD CONSTRAINT team_week_result_pkey PRIMARY KEY (team_id, year, week, postseason);
+    ADD CONSTRAINT team_week_result_pkey PRIMARY KEY (team_id, year, week, postseason, sport);
 
 
 --

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -689,7 +689,7 @@ ALTER TABLE ONLY public.team_game_stats
 --
 
 ALTER TABLE ONLY public.team_week_results
-    ADD CONSTRAINT team_week_result_team_id_fkey FOREIGN KEY (team_id) REFERENCES public.team_names(team_id) ON DELETE CASCADE;
+    ADD CONSTRAINT team_week_result_team_id_fkey FOREIGN KEY (team_id, sport) REFERENCES public.team_names(team_id, sport) ON DELETE CASCADE;
 
 
 --

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -11,26 +11,65 @@ FinalRaw = (Record * 0.60) + (SRS_normalized * 0.30) + (SOS_normalized * 0.10)
 - **60% Win-Loss Record** — The most important factor. Teams that win more
   games should rank higher.
 - **30% SRS (Simple Rating System)** — An iterative margin-of-victory rating
-  adjusted for opponent strength. Run with two margin-of-victory caps (1 and 30)
-  and averaged. The dual-MOV approach balances "did you win?" (MOV=1) with
-  "did you dominate?" (MOV=30) while preventing blowouts from distorting ratings.
-  Iterates up to 10,000 times or until convergence.
+  adjusted for opponent strength. Run with two margin-of-victory caps and
+  averaged. The dual-MOV approach balances "did you win?" with "did you
+  dominate?" while preventing blowouts from distorting ratings. Iterates up to
+  10,000 times or until convergence.
 - **10% SOS (Strength of Schedule)** — Solved via Cholesky decomposition of a
   system of linear equations. Measures quality of opponents independent of the
   team's own performance.
 
 All component scores are min-max normalized to [0,1] before weighting.
 
+### Sport-Specific Constants
+
+The same algorithm is used for both football and basketball, but with different
+tuning parameters:
+
+| Parameter | Football | Basketball | Rationale |
+|-----------|----------|------------|-----------|
+| `requiredGames` | 12 | 25 | Basketball plays ~30 games/season vs ~12 for football |
+| `yearsBack` | 2 | 1 | Basketball has more games, less need for historical backfill |
+| MOV caps | [1, 30] | [1, 20] | Basketball has narrower score variance |
+
 ## SRS Backfill: The James Madison Problem
 
 When a team transitions divisions (e.g., JMU moving to FBS in 2022), they may
 have very few intra-division games early in the season. The SRS algorithm
-requires a minimum of 12 games (`requiredGames`) per team. If a team has fewer,
-games from up to 2 previous seasons (`yearsBack`) are included. If still short,
+requires a minimum of `requiredGames` per team. If a team has fewer,
+games from previous seasons (`yearsBack`) are included. If still short,
 a targeted backfill query fetches additional historical games. This prevents
 small sample sizes from distorting the entire rating scale.
 
-See `internal/ranking/rating.go:199-228`.
+See `internal/ranking/rating.go`.
+
+## Multi-Sport via Sport Column (Not Separate Tables)
+
+Football and basketball data share the same tables (`games`, `team_names`,
+`team_seasons`, `team_week_results`) differentiated by a `sport` column
+(`"cfb"` or `"cbb"`). This avoids duplicating schema definitions and keeps
+queries simple — just add `WHERE sport = ?`. The alternative (separate tables
+per sport) was rejected because the data models are identical and separate
+tables would mean duplicating every query and migration.
+
+The `sport` column defaults to `"cfb"` for backward compatibility with existing
+football-only data.
+
+## Per-Client ESPN URLs (Not Package-Level Vars)
+
+When supporting multiple sports in a single process (the `schedule` command),
+each sport needs its own ESPN API URLs. Rather than using package-level vars
+that would conflict when both sports run simultaneously, each `espn.Client`
+carries its own URL set. The `NewClientForSport(sport)` constructor configures
+sport-specific URLs. The legacy `NewClient()` leaves per-client URLs empty,
+falling back to package-level vars for test compatibility.
+
+## Basketball: D1 Only, No Division Split
+
+Unlike football (which has FBS and FCS divisions requiring separate rankings),
+basketball only ranks D1 teams as a single group. The `FBS` column in
+`team_seasons` is reused to mean "top division" — all D1 basketball teams get
+`FBS=1`. The ranking code skips the FCS path for basketball.
 
 ## Dual Database Support (PostgreSQL + SQLite)
 
@@ -53,7 +92,7 @@ Key design choices:
 - **200ms rate limiting** between sequential API calls (in `game/` package) to
   avoid being blocked.
 - **5 retries with 1s backoff** on HTTP failures (in `espn/request.go`).
-- **URL vars instead of constants** — ESPN endpoint URLs are `var` not `const`
+- **URL vars as fallback** — ESPN endpoint URLs are `var` not `const`
   so tests can override them with a mock HTTP server.
 
 ## Writer Interface for Output
@@ -64,15 +103,25 @@ interface. This allows:
 - Local dev: plain JSON files written to disk
 - Testing: mock writers
 
-## Scheduled Updates During Football Season
+JSON output paths are sport-prefixed (`cfb/ranking/...`, `cbb/ranking/...`) to
+keep football and basketball data separate in the output bucket.
 
-The updater runs on cron schedules scoped to football season months (Aug-Jan):
+## Scheduled Updates During Season
+
+The updater runs on cron schedules scoped to each sport's season months:
+
+**Football (Aug–Jan):**
 - **Every 5 minutes:** Check for newly completed games
 - **Sundays at 5am:** Refresh team metadata
 - **August 10th at 6am:** Initialize the new season
 
-This avoids wasting resources during the offseason while ensuring near-real-time
-updates during games.
+**Basketball (Nov–Apr):**
+- **Every 5 minutes:** Check for newly completed games
+- **Sundays at 5am:** Refresh team metadata
+- **November 1st at 6am:** Initialize the new season
+
+Both sports run in a single process via the `schedule` command, each with its
+own update channel and goroutine.
 
 ## Panic Recovery in Scheduler
 

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -53,7 +53,10 @@ per sport) was rejected because the data models are identical and separate
 tables would mean duplicating every query and migration.
 
 The `sport` column defaults to `"cfb"` for backward compatibility with existing
-football-only data.
+football-only data. ESPN uses the same team IDs for a school across sports
+(e.g., Alabama's team_id is identical in football and basketball), so
+`team_names` requires `(team_id, sport)` as its primary key to store per-sport
+metadata without overwriting.
 
 ## Per-Client ESPN URLs (Not Package-Level Vars)
 

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -92,7 +92,7 @@ frontend. See [espn-api.md](espn-api.md) for endpoint details.
 Key design choices:
 - **Filter on `STATUS_FINAL` only** — Only completed games are ingested to
   avoid partial data.
-- **200ms rate limiting** between sequential API calls (in `game/` package) to
+- **500ms rate limiting** between sequential API calls (in `game/` package) to
   avoid being blocked.
 - **5 retries with 1s backoff** on HTTP failures (in `espn/request.go`).
 - **URL vars as fallback** — ESPN endpoint URLs are `var` not `const`

--- a/docs/migration-rules.md
+++ b/docs/migration-rules.md
@@ -1,0 +1,75 @@
+# Migration Rules
+
+Database migrations in this repo are managed via GORM `AutoMigrate` in
+`internal/database/`. Migrations affect the shared SQLite (local/ranker) and
+PostgreSQL (production) databases.
+
+## Core Rules
+
+### Additive first
+
+New columns must be nullable or carry a server-side DEFAULT. Never add a NOT
+NULL column without a default to an existing table in a single migration — this
+breaks any running instance that tries to insert a row before deploying the new
+code.
+
+```sql
+-- Wrong: breaks existing inserts immediately
+ALTER TABLE games ADD COLUMN source TEXT NOT NULL;
+
+-- Right: nullable first, tighten later if needed
+ALTER TABLE games ADD COLUMN source TEXT;
+```
+
+### Separate add from drop
+
+If you are replacing a column, the removal is a separate migration that lands
+after `stats-web` has been deployed and is no longer reading the old field. The
+sequence is:
+
+1. Migration: add new column.
+2. Backend code: write to both columns during transition.
+3. `stats-web` deploy: switch reads to new column.
+4. Migration: drop old column.
+
+Never add and drop in the same migration.
+
+### Destructive migrations require a rollback plan
+
+Dropping a table, column, or index requires a written rollback plan in the PR
+body. "Delete the data" is not a plan. Describe what a revert deploy looks like
+and whether data recovery is possible.
+
+### Migrations are forward-only
+
+Write every migration as if you cannot roll it back. If a migration turns out
+to be wrong, the fix is a new forward migration — not an edit to an already-run
+one. Editing a migration that has run in production produces divergence between
+the recorded schema and actual state.
+
+### Test against populated data
+
+Before merging, run the migration against a database that already has rows in
+the affected tables. An empty-schema test is not sufficient — migrations that
+assume columns are empty or tables have specific row counts will fail in
+production.
+
+## Schema Design Constraints
+
+- Shared tables (`games`, `team_names`, `team_seasons`, `team_week_results`)
+  carry a `sport` column (`"cfb"` or `"cbb"`). New columns on these tables
+  must be sport-agnostic or include sport-specific defaults.
+- `team_names` uses `(team_id, sport)` as its composite primary key. ESPN
+  reuses team IDs across sports. Do not collapse this back to a single-column
+  primary key.
+- The `fbs` column in `team_seasons` means "top division" for both sports
+  (`fbs=1` for FBS football, `fbs=1` for D1 basketball). This is acknowledged
+  tech debt — do not rename it without a migration and a corresponding update
+  to every query that references it.
+
+## When Schema Hacks Are Unavoidable
+
+If a schema compromise is necessary (e.g., reusing a column for a second
+meaning, storing structured data as a string), it must be recorded immediately
+in `docs/tech-debt.md` with a description of the intended clean-up path. Silent
+hacks compound over time and become load-bearing.

--- a/docs/multi-repo-workflow.md
+++ b/docs/multi-repo-workflow.md
@@ -1,0 +1,66 @@
+# Multi-Repo Feature Workflow
+
+This repo (`stats-go`) is the integration source of truth. The sibling repo
+`stats-web` is a static frontend consumer. There is no hub repo.
+
+## Ownership
+
+| Concern | Owner |
+|---|---|
+| Docker Compose (backend + Postgres) | `stats-go` |
+| Database schema and migrations | `stats-go` |
+| API contracts (paths, fields, HTTP semantics) | `stats-go` |
+| Frontend rendering and UX | `stats-web` |
+
+When there is a conflict about who owns something, `stats-go` wins.
+
+## Feature Workflow
+
+All cross-repo features start here. This sequence is non-negotiable:
+
+1. **Define the contract in `stats-go`.** Write the migration, update models,
+   implement the endpoint. Finalize field names and response shapes before any
+   frontend work begins.
+2. **Validate the full stack locally.** `docker compose up` must be green.
+   New or changed endpoints must return correct responses.
+3. **Open a `stats-go` PR.** Get it reviewed and merged (or at minimum freeze
+   the contract) before touching `stats-web`.
+4. **Then open a `stats-web` PR** that consumes the finalized contract.
+
+One PR per repo per feature slice. Do not batch unrelated changes into a
+cross-repo feature branch.
+
+## Mixed-Version Deployment
+
+During rollout, the backend and frontend will briefly be at different versions.
+Design for this:
+
+- **New fields may be absent** on an older backend. The frontend must handle
+  missing fields gracefully (don't crash on undefined).
+- **Old fields must remain present** until the frontend no longer reads them.
+  Do not remove a response field in the same deploy that the frontend stops
+  using it — these are separate deploys.
+- **Never make a breaking API change** (removing a field, changing a field type,
+  altering HTTP semantics) without a versioning plan documented in the PR.
+
+## Validation Checklist
+
+Before declaring a backend feature complete and unblocking `stats-web` work:
+
+- [ ] `go test ./...` — no failures
+- [ ] `golangci-lint run --config=.golangci.yml ./cmd/... ./internal/...` — clean
+- [ ] `docker compose up` — stack starts and is healthy
+- [ ] New or changed endpoints return correct responses
+- [ ] Migrations run cleanly on a fresh database
+- [ ] Migrations run cleanly on a populated database (no data loss)
+- [ ] API contract documented in the PR description (fields, types, method, path)
+- [ ] `ARCHITECTURE.md` and `docs/` updated if interfaces or packages changed
+
+## `stats-web` Coordination Rules
+
+- All API questions are resolved in `stats-go`. Do not negotiate shape in the
+  frontend repo — open a `stats-go` issue or PR and fix it at the source.
+- Do not add a `stats-web` workaround for a `stats-go` bug. Fix the backend.
+- Do not duplicate the rules in this file in `stats-web`. Point to this file.
+- `stats-web` runs locally against this backend. If local setup is broken,
+  the fix lives here.

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -1,33 +1,102 @@
 # Tech Debt Tracker
 
+<!--
+Format rules:
+- Active items go under ## Active with a ### heading describing the issue.
+- When an item is resolved, move it to ## Resolved (at the bottom).
+  Add "(resolved YYYY-MM-DD)" to the heading and write a brief note on
+  what was done. Do NOT use strikethrough or leave resolved items under Active.
+- Keep items in reverse-chronological order within each section (newest first).
+-->
+
 ## Active
 
-### ~~No integration tests~~ (resolved 2026-02-13)
+### `FBS` column overloaded as "top division" flag
+
+The `fbs` column in `team_seasons` means "FBS" for football but "D1" for
+basketball. All D1 basketball teams are stored with `fbs=1`. This works but the
+column name is misleading when reading basketball queries. Renaming to something
+like `top_division` would require a migration and touching every query that
+references it.
+
+See `internal/updater/update_team_season.go:83` and `docs/design-decisions.md`.
+
+### Package-level ESPN URL vars exist only as test fallback
+
+Three package-level `var` declarations (`weekURL`, `gameStatsURL`, `teamInfoURL`)
+exist solely so the legacy `NewClient()` constructor — used only in two test
+files — can have its URLs overridden via `SetTestURLs()`. Production code uses
+`NewClientForSport()` which sets per-client URLs directly. The fallback chain
+(`Client.WeekURL()` etc.) adds indirection for no production benefit.
+
+Eliminating `NewClient()` in favor of `NewClientForSport()` everywhere (including
+tests) would allow removing the package-level vars, the `SetTestURLs` function,
+and the fallback methods.
+
+See `internal/espn/request.go:58-79`.
+
+### `fmt.Println` in ranker CLI for error and duration output
+
+`cmd/ranker/main.go` prints `err` (which may be `nil`) and `duration` via
+`fmt.Println` with `//nolint:forbidigo` suppression. Printing a nil error
+produces a confusing `<nil>` line. The error should be checked and the duration
+should use structured output or be omitted.
+
+## Resolved
+
+### `team_names` primary key missing `sport` (resolved 2026-02-14)
+
+ESPN uses the same team IDs across sports for the same school. The `team_names`
+table had `team_id` as its sole primary key, so `UpdateTeamInfo` for one sport
+would overwrite the other sport's row. Fixed by adding `sport` to the
+`team_names` primary key and updating the join in `createTeamList`.
+
+### Silent football fallback on unknown sport (resolved 2026-02-14)
+
+Multiple switch statements (`SportDB`, `Groups`, `SportURLs`, `sportConfig`,
+`sportFilter`) silently defaulted to football for unrecognized sport values.
+Fixed by panicking on unknown sport.
+
+### Unnamed multi-value returns in sport config (resolved 2026-02-14)
+
+`sportConfig()` returned `(int, int64, []int64)` and `SportURLs()` returned
+three unnamed strings. Replaced with `sportParams` and `SportURLConfig` structs.
+
+### Schedule command cron boilerplate duplication (resolved 2026-02-14)
+
+The `scheduleCommand` function duplicated ~130 lines of goroutine/channel/cron
+registration for each sport. Extracted `sportSchedule.registerJobs` method.
+
+### No integration tests (resolved 2026-02-13)
+
 Added integration tests in `internal/updater/` behind a `//go:build integration`
 tag. Tests exercise the full pipeline (fetch → parse → store → rank → export)
 against an in-memory SQLite database with a mock ESPN HTTP server and a
 capturing writer. CI runs integration tests as a separate job.
 
-### ~~ESPN API fragility~~ (resolved 2026-02-13)
+### ESPN API fragility (resolved 2026-02-13)
+
 Added HTTP status code validation and 5xx retry in `makeRequest`, wrapped JSON
 decode errors with endpoint context, added `validate()` methods on all three
 response types (`GameScheduleESPN`, `GameInfoESPN`, `TeamInfoESPN`), and guarded
 remaining unprotected slice index accesses in `espn.go`.
 
-### ~~Hard-coded rate limiting~~ (resolved 2026-02-13)
+### Hard-coded rate limiting (resolved 2026-02-13)
+
 Introduced `espn.Client` struct with configurable `MaxRetries`,
 `InitialBackoff`, `RequestTimeout`, and `RateLimit` fields. Retry logic now
 uses exponential backoff (`initialBackoff * 2^attempt`, capped at 30s).
 
-## Resolved
-
 ### Updater CLI flag surface area (resolved 2026-02-13)
+
 Replaced 8 flat boolean flags with cobra subcommands (`schedule`, `games`,
 `ranking`, `teams`, `season`, `json`). Each subcommand owns its own flags.
 
 ### Home field advantage constant unused (resolved 2026-02-13)
+
 Removed the dead `hfa` constant from `internal/ranking/rating.go`.
 
 ### Dependency versions are dated (resolved 2026-02-13)
+
 Upgraded Go 1.21 → 1.26, aws-sdk-go v1 → v2, gocron v1 → v2, GORM
 drivers to pgx/v5, and zap to v1.27. All dependencies are now current.

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -11,6 +11,22 @@ Format rules:
 
 ## Active
 
+### Basketball historical season support not yet implemented
+
+Basketball ESPN methods (`GetGamesBySeason`, `GetWeeksInSeason`,
+`TeamConferencesByYear`, `HasPostseasonStarted`) only support the current
+season. A `validateCurrentSeason` guard returns an error for non-current years.
+Implementing historical support requires finding a year-parameterized ESPN
+endpoint for basketball or building a season-date archive.
+
+### `games` PK missing `sport` — cross-sport collision risk
+
+`games` table uses `game_id` alone as PK. Unlike `team_names`, `team_seasons`,
+and `team_week_results` (which all include `sport`), `games` relies on ESPN
+using separate ID spaces per sport. If that assumption breaks,
+`OnConflict{UpdateAll: true}` silently overwrites data. Fix requires a
+multi-step migration touching FK constraints — separate PR.
+
 ### ESPN teams endpoint missing some D1 basketball teams
 
 The `/teams?limit=1000` endpoint doesn't return all D1 basketball teams. At

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -11,6 +11,16 @@ Format rules:
 
 ## Active
 
+### ESPN teams endpoint missing some D1 basketball teams
+
+The `/teams?limit=1000` endpoint doesn't return all D1 basketball teams. At
+least 3 teams (IDs 2511, 88, 2815) appear in schedule data with D1 conference
+IDs but are absent from the teams response. These teams get `team_seasons` rows
+but no `team_names` entry, so they show up in rankings with empty names/logos.
+
+May need to increase the limit, paginate, or backfill missing teams from game
+data.
+
 ### `FBS` column overloaded as "top division" flag
 
 The `fbs` column in `team_seasons` means "FBS" for football but "D1" for

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -17,9 +17,9 @@ func (Conference) TableName() string {
 }
 
 type TeamName struct {
-	TeamID           int64  `json:"team_id" gorm:"column:team_id;primaryKey;not null;unique"`
+	TeamID           int64  `json:"team_id" gorm:"column:team_id;primaryKey;not null"`
 	Name             string `json:"name" gorm:"column:name;not null"`
-	Sport            string `json:"sport" gorm:"column:sport;default:cfb"`
+	Sport            string `json:"sport" gorm:"column:sport;primaryKey;default:cfb"`
 	Flair            string `json:"flair" gorm:"column:flair"`
 	Abbreviation     string `json:"abbreviation" gorm:"column:abbreviation"`
 	AltColor         string `json:"altColor" gorm:"column:alt_color"`

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -19,6 +19,7 @@ func (Conference) TableName() string {
 type TeamName struct {
 	TeamID           int64  `json:"team_id" gorm:"column:team_id;primaryKey;not null;unique"`
 	Name             string `json:"name" gorm:"column:name;not null"`
+	Sport            string `json:"sport" gorm:"column:sport;default:cfb"`
 	Flair            string `json:"flair" gorm:"column:flair"`
 	Abbreviation     string `json:"abbreviation" gorm:"column:abbreviation"`
 	AltColor         string `json:"altColor" gorm:"column:alt_color"`
@@ -41,6 +42,7 @@ func (TeamName) TableName() string {
 type TeamSeason struct {
 	TeamID int64  `json:"team_id" gorm:"column:team_id;primaryKey;not null"`
 	Year   int64  `json:"year" gorm:"column:year;primaryKey"`
+	Sport  string `json:"sport" gorm:"column:sport;primaryKey;default:cfb"`
 	FBS    int64  `json:"fbs" gorm:"column:fbs"`
 	Conf   string `json:"conf" gorm:"column:conf"`
 }
@@ -56,6 +58,7 @@ type TeamWeekResult struct {
 	Year       int64   `json:"year" gorm:"column:year;primaryKey;not null"`
 	Week       int64   `json:"week" gorm:"column:week;primaryKey;not null"`
 	Postseason int64   `json:"postseason" gorm:"column:postseason;primaryKey"`
+	Sport      string  `json:"sport" gorm:"column:sport;primaryKey;default:cfb"`
 	FinalRank  int64   `json:"final_rank" gorm:"column:final_rank"`
 	FinalRaw   float64 `json:"final_raw" gorm:"column:final_raw"`
 	Wins       int64   `json:"wins" gorm:"column:wins"`
@@ -75,6 +78,7 @@ func (TeamWeekResult) TableName() string {
 type Game struct {
 	GameID     int64     `json:"game_id" gorm:"column:game_id;primaryKey;not null;unique"`
 	StartTime  time.Time `json:"start_time" gorm:"column:start_time"`
+	Sport      string    `json:"sport" gorm:"column:sport;default:cfb"`
 	Neutral    bool      `json:"neutral" gorm:"column:neutral"`
 	ConfGame   bool      `json:"conf_game" gorm:"column:conf_game"`
 	Season     int64     `json:"season" gorm:"column:season"`

--- a/internal/espn/basketball.go
+++ b/internal/espn/basketball.go
@@ -1,0 +1,124 @@
+package espn
+
+import (
+	"fmt"
+	"maps"
+	"time"
+)
+
+// BasketballClient wraps a shared *Client with basketball-specific season logic.
+type BasketballClient struct{ *Client }
+
+// Compile-time interface check.
+var _ SportClient = (*BasketballClient)(nil)
+
+func (bc *BasketballClient) DefaultSeason() (int64, error) {
+	sb, err := bc.GetScoreboard()
+	if err != nil {
+		return 0, err
+	}
+	return sb.Leagues[0].Season.Year, nil
+}
+
+func (bc *BasketballClient) GetWeeksInSeason(_ int64) (int64, error) {
+	return bc.getWeeksInSeasonFromScoreboard()
+}
+
+func (bc *BasketballClient) getWeeksInSeasonFromScoreboard() (int64, error) {
+	sb, err := bc.GetScoreboard()
+	if err != nil {
+		return 0, err
+	}
+
+	season := sb.Leagues[0].Season
+	start, err := time.Parse("2006-01-02T15:04Z", season.StartDate)
+	if err != nil {
+		return 0, fmt.Errorf("parsing season start date: %w", err)
+	}
+	end, err := time.Parse("2006-01-02T15:04Z", season.EndDate)
+	if err != nil {
+		return 0, fmt.Errorf("parsing season end date: %w", err)
+	}
+
+	days := end.Sub(start).Hours() / 24
+	weeks := int64(days/7) + 1
+	return weeks, nil
+}
+
+func (bc *BasketballClient) HasPostseasonStarted(_ int64, _ time.Time) (bool, error) {
+	sb, err := bc.GetScoreboard()
+	if err != nil {
+		return false, err
+	}
+	return sb.Leagues[0].Season.Type.ID >= int64(Postseason), nil
+}
+
+func (bc *BasketballClient) GetGamesBySeason(_ int64, group Group) ([]Game, error) {
+	return bc.getGamesBySeasonDates(group)
+}
+
+func (bc *BasketballClient) getGamesBySeasonDates(group Group) ([]Game, error) {
+	dates, err := bc.GetSeasonDates()
+	if err != nil {
+		return nil, err
+	}
+
+	var allGames []Game
+	for _, dateStr := range dates {
+		date := dateToParam(dateStr)
+		games, err := bc.GetCompletedGamesByDate(date, group)
+		if err != nil {
+			return nil, err
+		}
+		allGames = append(allGames, games...)
+		time.Sleep(bc.RateLimit)
+	}
+
+	return allGames, nil
+}
+
+func (bc *BasketballClient) TeamConferencesByYear(_ int64) (map[int64]int64, error) {
+	return bc.teamConferencesByDates()
+}
+
+func (bc *BasketballClient) teamConferencesByDates() (map[int64]int64, error) {
+	dates, err := bc.GetSeasonDates()
+	if err != nil {
+		return nil, err
+	}
+
+	teamConfs := map[int64]int64{}
+	for _, group := range bc.Sport.Groups() {
+		for _, dateStr := range dates {
+			date := dateToParam(dateStr)
+			games, err := bc.GetGamesByDate(date, group)
+			if err != nil {
+				return nil, err
+			}
+			maps.Copy(teamConfs, extractTeamConfs(games))
+			time.Sleep(bc.RateLimit)
+		}
+	}
+
+	return teamConfs, nil
+}
+
+func (bc *BasketballClient) ConferenceMap() (map[Group]interface{}, error) {
+	var res GameScheduleESPN
+	err := bc.makeRequest(bc.WeekURL(), &res)
+	if err != nil {
+		return nil, err
+	}
+
+	conferences := res.Content.ConferenceAPI.Conferences
+
+	d1 := map[int64]string{}
+	for _, conference := range conferences {
+		if int64(conference.ParentGroupID) == int64(D1Basketball) {
+			d1[conference.GroupID] = conference.ShortName
+		}
+	}
+	return map[Group]interface{}{ //nolint:exhaustive // basketball only has D1
+		D1Basketball: d1,
+	}, nil
+}

--- a/internal/espn/espn.go
+++ b/internal/espn/espn.go
@@ -29,8 +29,9 @@ func (s Sport) SportDB() string {
 		return SportDBBasketball
 	case CollegeFootball:
 		return SportDBFootball
+	default:
+		panic(fmt.Sprintf("unknown sport: %q", s))
 	}
-	return SportDBFootball
 }
 
 type Group int64
@@ -56,8 +57,9 @@ func (s Sport) Groups() []Group {
 		return []Group{D1Basketball}
 	case CollegeFootball:
 		return []Group{FBS, FCS}
+	default:
+		panic(fmt.Sprintf("unknown sport: %q", s))
 	}
-	return []Group{FBS, FCS}
 }
 
 // HasDivisionSplit returns true if the sport distinguishes divisions (e.g. FBS/FCS).

--- a/internal/espn/espn.go
+++ b/internal/espn/espn.go
@@ -178,6 +178,9 @@ func (c *Client) GetTeamInfo() (*TeamInfoESPN, error) {
 func dateToParam(isoDate string) string {
 	t, err := time.Parse("2006-01-02T15:04Z", isoDate)
 	if err != nil {
+		if len(isoDate) < 10 {
+			return ""
+		}
 		// Best-effort: strip non-digits from the date portion.
 		return strings.ReplaceAll(isoDate[:10], "-", "")
 	}

--- a/internal/espn/espn_test.go
+++ b/internal/espn/espn_test.go
@@ -381,6 +381,42 @@ func TestGameInfoValidate(t *testing.T) {
 	}
 }
 
+func TestSportDB(t *testing.T) {
+	if got := CollegeFootball.SportDB(); got != "cfb" {
+		t.Errorf("CollegeFootball.SportDB() = %q, want %q", got, "cfb")
+	}
+	if got := CollegeBasketball.SportDB(); got != "cbb" {
+		t.Errorf("CollegeBasketball.SportDB() = %q, want %q", got, "cbb")
+	}
+}
+
+func TestGroups(t *testing.T) {
+	fbGroups := CollegeFootball.Groups()
+	if len(fbGroups) != 2 {
+		t.Fatalf("CollegeFootball.Groups() len = %d, want 2", len(fbGroups))
+	}
+	if fbGroups[0] != FBS || fbGroups[1] != FCS {
+		t.Errorf("CollegeFootball.Groups() = %v, want [FBS, FCS]", fbGroups)
+	}
+
+	bbGroups := CollegeBasketball.Groups()
+	if len(bbGroups) != 1 {
+		t.Fatalf("CollegeBasketball.Groups() len = %d, want 1", len(bbGroups))
+	}
+	if bbGroups[0] != D1Basketball {
+		t.Errorf("CollegeBasketball.Groups() = %v, want [D1Basketball]", bbGroups)
+	}
+}
+
+func TestHasDivisionSplit(t *testing.T) {
+	if !CollegeFootball.HasDivisionSplit() {
+		t.Error("CollegeFootball.HasDivisionSplit() = false, want true")
+	}
+	if CollegeBasketball.HasDivisionSplit() {
+		t.Error("CollegeBasketball.HasDivisionSplit() = true, want false")
+	}
+}
+
 func TestTeamInfoValidate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -394,12 +430,12 @@ func TestTeamInfoValidate(t *testing.T) {
 		},
 		{
 			name:    "no leagues",
-			resp:    TeamInfoESPN{Sports: []Sport{{}}},
+			resp:    TeamInfoESPN{Sports: []TeamInfoSport{{}}},
 			wantErr: "missing leagues",
 		},
 		{
 			name:    "no teams",
-			resp:    TeamInfoESPN{Sports: []Sport{{Leagues: []League{{}}}}},
+			resp:    TeamInfoESPN{Sports: []TeamInfoSport{{Leagues: []League{{}}}}},
 			wantErr: "missing teams",
 		},
 	}

--- a/internal/espn/football.go
+++ b/internal/espn/football.go
@@ -113,11 +113,11 @@ func (fc *FootballClient) TeamConferencesByYear(year int64) (map[int64]int64, er
 	return teamConfs, nil
 }
 
-func (fc *FootballClient) ConferenceMap() (map[Group]interface{}, error) {
+func (fc *FootballClient) ConferenceMap() (ConferenceMapResult, error) {
 	var res GameScheduleESPN
 	err := fc.makeRequest(fc.WeekURL(), &res)
 	if err != nil {
-		return nil, err
+		return ConferenceMapResult{}, err
 	}
 
 	conferences := res.Content.ConferenceAPI.Conferences
@@ -148,10 +148,14 @@ func (fc *FootballClient) ConferenceMap() (map[Group]interface{}, error) {
 		}
 	}
 
-	return map[Group]interface{}{ //nolint:exhaustive // football doesn't have D1Basketball
-		FBS:  fbs,
-		FCS:  fcs,
-		DII:  dii,
-		DIII: diii,
+	return ConferenceMapResult{
+		Conferences: map[Group]map[int64]string{ //nolint:exhaustive // football doesn't have D1Basketball
+			FBS: fbs,
+			FCS: fcs,
+		},
+		SubGroups: map[Group][]int64{ //nolint:exhaustive // only DII/DIII have sub-groups
+			DII:  dii,
+			DIII: diii,
+		},
 	}, nil
 }

--- a/internal/espn/football.go
+++ b/internal/espn/football.go
@@ -1,0 +1,157 @@
+package espn
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+	"time"
+)
+
+// FootballClient wraps a shared *Client with football-specific season logic.
+type FootballClient struct{ *Client }
+
+// Compile-time interface check.
+var _ SportClient = (*FootballClient)(nil)
+
+func (fc *FootballClient) DefaultSeason() (int64, error) {
+	var res GameScheduleESPN
+	err := fc.makeRequest(fc.WeekURL(), &res)
+	if err != nil {
+		return 0, err
+	}
+
+	return res.Content.Defaults.Year, nil
+}
+
+func (fc *FootballClient) GetWeeksInSeason(year int64) (int64, error) {
+	url := fc.WeekURL() + fmt.Sprintf("&year=%d", year)
+
+	var res GameScheduleESPN
+	err := fc.makeRequest(url, &res)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(res.Content.Calendar) == 0 || len(res.Content.Calendar[0].Weeks) == 0 {
+		return 0, fmt.Errorf("schedule response missing calendar/weeks for year %d", year)
+	}
+
+	return int64(len(res.Content.Calendar[0].Weeks)), nil
+}
+
+func (fc *FootballClient) HasPostseasonStarted(year int64, startTime time.Time) (bool, error) {
+	url := fc.WeekURL() + fmt.Sprintf("&year=%d", year)
+
+	var res GameScheduleESPN
+	err := fc.makeRequest(url, &res)
+	if err != nil {
+		return false, err
+	}
+
+	if len(res.Content.Calendar) < 2 {
+		return false, fmt.Errorf("schedule response has %d calendar entries, need at least 2 for postseason",
+			len(res.Content.Calendar))
+	}
+
+	postSeasonStart, _ := time.Parse("2006-01-02T15:04Z",
+		res.Content.Calendar[1].StartDate)
+	return postSeasonStart.Before(startTime), nil
+}
+
+func (fc *FootballClient) GetGamesBySeason(year int64, group Group) ([]Game, error) {
+	var allGames []Game
+
+	numWeeks, err := fc.GetWeeksInSeason(year)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := int64(1); i < numWeeks; i++ {
+		games, err := fc.GetCompletedGamesByWeek(year, i, group, Regular)
+		if err != nil {
+			return nil, err
+		}
+
+		allGames = append(allGames, games...)
+	}
+
+	games, err := fc.GetCompletedGamesByWeek(year, int64(1), group, Postseason)
+	if err != nil {
+		return nil, err
+	}
+
+	allGames = append(allGames, games...)
+
+	return allGames, nil
+}
+
+func (fc *FootballClient) TeamConferencesByYear(year int64) (map[int64]int64, error) {
+	teamConfs := map[int64]int64{}
+
+	numWeeks, err := fc.GetWeeksInSeason(year)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, group := range fc.Sport.Groups() {
+		for i := int64(1); i < numWeeks; i++ {
+			games, err := fc.GetGamesByWeek(year, i, group, Regular)
+			if err != nil {
+				return nil, err
+			}
+			maps.Copy(teamConfs, extractTeamConfs(games))
+		}
+
+		games, err := fc.GetGamesByWeek(year, int64(1), group, Postseason)
+		if err != nil {
+			return nil, err
+		}
+		maps.Copy(teamConfs, extractTeamConfs(games))
+	}
+
+	return teamConfs, nil
+}
+
+func (fc *FootballClient) ConferenceMap() (map[Group]interface{}, error) {
+	var res GameScheduleESPN
+	err := fc.makeRequest(fc.WeekURL(), &res)
+	if err != nil {
+		return nil, err
+	}
+
+	conferences := res.Content.ConferenceAPI.Conferences
+
+	fbs := map[int64]string{}
+	fcs := map[int64]string{}
+	dii := []int64{}
+	diii := []int64{}
+
+	for _, conference := range conferences {
+		switch int64(conference.ParentGroupID) {
+		case int64(FBS):
+			fbs[conference.GroupID] = conference.ShortName
+		case int64(FCS):
+			fcs[conference.GroupID] = conference.ShortName
+		default:
+			if slices.Contains([]int64{int64(DII), int64(DIII)}, conference.GroupID) {
+				for _, conf := range conference.SubGroups {
+					group, _ := strconv.ParseInt(conf, 10, 64)
+					switch conference.GroupID {
+					case int64(DII):
+						dii = append(dii, group)
+					case int64(DIII):
+						diii = append(diii, group)
+					}
+				}
+			}
+		}
+	}
+
+	return map[Group]interface{}{ //nolint:exhaustive // football doesn't have D1Basketball
+		FBS:  fbs,
+		FCS:  fcs,
+		DII:  dii,
+		DIII: diii,
+	}, nil
+}

--- a/internal/espn/game_schedule_espn.go
+++ b/internal/espn/game_schedule_espn.go
@@ -2,6 +2,7 @@ package espn
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 )
 
@@ -118,5 +119,9 @@ func (f *FlexInt64) UnmarshalJSON(b []byte) error {
 func (r GameScheduleESPN) validate() error {
 	// Calendar is only present in football schedule responses. Basketball
 	// schedule responses omit it entirely, so we cannot require it here.
+	// However, both sports must return schedule data.
+	if len(r.Content.Schedule) == 0 {
+		return fmt.Errorf("empty schedule in response")
+	}
 	return nil
 }

--- a/internal/espn/game_schedule_espn.go
+++ b/internal/espn/game_schedule_espn.go
@@ -1,6 +1,9 @@
 package espn
 
-import "errors"
+import (
+	"encoding/json"
+	"strconv"
+)
 
 //nolint:gochecknoglobals // overridden in tests
 var weekURL = "https://cdn.espn.com/core/college-football/schedule?xhr=1&render=false&userab=18"
@@ -53,10 +56,10 @@ type StatusType struct {
 }
 
 type Parameters struct {
-	Week       int64 `json:"week"`
-	Year       int64 `json:"year"`
-	SeasonType int64 `json:"seasonType"`
-	Group      int64 `json:"group,string"`
+	Week       int64     `json:"week"`
+	Year       int64     `json:"year"`
+	SeasonType int64     `json:"seasonType"`
+	Group      FlexInt64 `json:"group"`
 }
 
 type Calendar struct {
@@ -77,20 +80,43 @@ type ConferenceAPI struct {
 }
 
 type Conference struct {
-	GroupID       int64    `json:"groupId,string"`
-	Name          string   `json:"name"`
-	SubGroups     []string `json:"subGroups"` // is an array of ints though
-	Logo          string   `json:"logo"`
-	ParentGroupID int64    `json:"parentGroupId,string"`
-	ShortName     string   `json:"shortName"`
+	GroupID       int64     `json:"groupId,string"`
+	Name          string    `json:"name"`
+	SubGroups     []string  `json:"subGroups"` // is an array of ints though
+	Logo          string    `json:"logo"`
+	ParentGroupID FlexInt64 `json:"parentGroupId"`
+	ShortName     string    `json:"shortName"`
+}
+
+// FlexInt64 unmarshals a JSON value that may be a number, a quoted string, or null.
+type FlexInt64 int64
+
+func (f *FlexInt64) UnmarshalJSON(b []byte) error {
+	if string(b) == "null" {
+		*f = 0
+		return nil
+	}
+	// Try as a bare number first.
+	var n int64
+	if err := json.Unmarshal(b, &n); err == nil {
+		*f = FlexInt64(n)
+		return nil
+	}
+	// Fall back to a quoted string.
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return err
+	}
+	*f = FlexInt64(n)
+	return nil
 }
 
 func (r GameScheduleESPN) validate() error {
-	if len(r.Content.Calendar) == 0 {
-		return errors.New("schedule response missing calendar entries")
-	}
-	if len(r.Content.Calendar[0].Weeks) == 0 {
-		return errors.New("schedule response has empty weeks in first calendar entry")
-	}
+	// Calendar is only present in football schedule responses. Basketball
+	// schedule responses omit it entirely, so we cannot require it here.
 	return nil
 }

--- a/internal/espn/request.go
+++ b/internal/espn/request.go
@@ -35,7 +35,7 @@ func NewClient() SportClient {
 		MaxRetries:     5,
 		InitialBackoff: 1 * time.Second,
 		RequestTimeout: 1 * time.Second,
-		RateLimit:      200 * time.Millisecond,
+		RateLimit:      500 * time.Millisecond,
 		Sport:          CollegeFootball,
 	}}
 }
@@ -47,7 +47,7 @@ func NewClientForSport(sport Sport) SportClient {
 		MaxRetries:     5,
 		InitialBackoff: 1 * time.Second,
 		RequestTimeout: 1 * time.Second,
-		RateLimit:      200 * time.Millisecond,
+		RateLimit:      500 * time.Millisecond,
 		Sport:          sport,
 		scheduleURL:    urls.Schedule,
 		gameStatsURL:   urls.GameStats,

--- a/internal/espn/request.go
+++ b/internal/espn/request.go
@@ -65,7 +65,7 @@ func wrapClient(c *Client) SportClient {
 	case CollegeFootball:
 		return &FootballClient{Client: c}
 	default:
-		return &FootballClient{Client: c}
+		panic(fmt.Sprintf("unsupported sport: %s", c.Sport))
 	}
 }
 
@@ -95,7 +95,10 @@ func (c *Client) TeamInfoURL() string {
 
 // ScoreboardURL returns the scoreboard URL for this client.
 func (c *Client) ScoreboardURL() string {
-	return c.scoreboardURL
+	if c.scoreboardURL != "" {
+		return c.scoreboardURL
+	}
+	return scoreboardURL
 }
 
 type validatable interface {

--- a/internal/espn/request.go
+++ b/internal/espn/request.go
@@ -41,16 +41,16 @@ func NewClient() *Client {
 
 // NewClientForSport returns a Client configured for the given sport.
 func NewClientForSport(sport Sport) *Client {
-	schedule, game, team := SportURLs(sport)
+	urls := SportURLs(sport)
 	return &Client{
 		MaxRetries:     5,
 		InitialBackoff: 1 * time.Second,
 		RequestTimeout: 1 * time.Second,
 		RateLimit:      200 * time.Millisecond,
 		Sport:          sport,
-		scheduleURL:    schedule,
-		gameStatsURL:   game,
-		teamInfoURL:    team,
+		scheduleURL:    urls.Schedule,
+		gameStatsURL:   urls.GameStats,
+		teamInfoURL:    urls.TeamInfo,
 	}
 }
 

--- a/internal/espn/scoreboard.go
+++ b/internal/espn/scoreboard.go
@@ -2,6 +2,9 @@ package espn
 
 import "errors"
 
+//nolint:gochecknoglobals // overridden in tests
+var scoreboardURL string
+
 // ScoreboardESPN represents the top-level response from the ESPN scoreboard API.
 // Used primarily for basketball where the schedule endpoint lacks season metadata.
 type ScoreboardESPN struct {

--- a/internal/espn/scoreboard.go
+++ b/internal/espn/scoreboard.go
@@ -1,0 +1,45 @@
+package espn
+
+import "errors"
+
+// ScoreboardESPN represents the top-level response from the ESPN scoreboard API.
+// Used primarily for basketball where the schedule endpoint lacks season metadata.
+type ScoreboardESPN struct {
+	Leagues []ScoreboardLeague `json:"leagues"`
+}
+
+// ScoreboardLeague contains season metadata and a flat calendar of game dates.
+type ScoreboardLeague struct {
+	Season   ScoreboardSeason `json:"season"`
+	Calendar []string         `json:"calendar"`
+}
+
+// ScoreboardSeason holds the year and date range for a season.
+type ScoreboardSeason struct {
+	Year      int64                `json:"year"`
+	StartDate string               `json:"startDate"`
+	EndDate   string               `json:"endDate"`
+	Type      ScoreboardSeasonType `json:"type"`
+}
+
+// ScoreboardSeasonType identifies the current phase of a season.
+type ScoreboardSeasonType struct {
+	ID   int64  `json:"type"`
+	Name string `json:"name"`
+}
+
+func (r ScoreboardESPN) validate() error {
+	if len(r.Leagues) == 0 {
+		return errors.New("scoreboard response missing leagues")
+	}
+	return nil
+}
+
+// GetScoreboard fetches the scoreboard endpoint for season metadata.
+func (c *Client) GetScoreboard() (*ScoreboardESPN, error) {
+	var res ScoreboardESPN
+	if err := c.makeRequest(c.ScoreboardURL(), &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}

--- a/internal/espn/sport_client.go
+++ b/internal/espn/sport_client.go
@@ -1,0 +1,34 @@
+package espn
+
+import "time"
+
+// SportClient is the interface for sport-specific ESPN API interactions.
+// Both FootballClient and BasketballClient implement it.
+type SportClient interface {
+	// Metadata
+	SportInfo() Sport
+	RateLimitDuration() time.Duration
+
+	// Game data (sport-agnostic)
+	GetCurrentWeekGames(group Group) ([]Game, error)
+	GetGameStats(gameID int64) (*GameInfoESPN, error)
+	GetTeamInfo() (*TeamInfoESPN, error)
+
+	// Season navigation (sport-specific)
+	DefaultSeason() (int64, error)
+	GetWeeksInSeason(year int64) (int64, error)
+	HasPostseasonStarted(year int64, startTime time.Time) (bool, error)
+	GetGamesBySeason(year int64, group Group) ([]Game, error)
+	TeamConferencesByYear(year int64) (map[int64]int64, error)
+	ConferenceMap() (map[Group]interface{}, error)
+}
+
+// SportInfo returns the sport this client is configured for.
+func (c *Client) SportInfo() Sport {
+	return c.Sport
+}
+
+// RateLimitDuration returns the delay between batch API calls.
+func (c *Client) RateLimitDuration() time.Duration {
+	return c.RateLimit
+}

--- a/internal/espn/sport_client.go
+++ b/internal/espn/sport_client.go
@@ -2,6 +2,16 @@ package espn
 
 import "time"
 
+// ConferenceMapResult holds conference data returned by ConferenceMap.
+type ConferenceMapResult struct {
+	// Conferences maps group → (conference ID → short name).
+	// Football populates FBS and FCS. Basketball populates D1Basketball.
+	Conferences map[Group]map[int64]string
+
+	// SubGroups maps group → sub-group IDs. Only used by football (DII, DIII).
+	SubGroups map[Group][]int64
+}
+
 // SportClient is the interface for sport-specific ESPN API interactions.
 // Both FootballClient and BasketballClient implement it.
 type SportClient interface {
@@ -20,7 +30,7 @@ type SportClient interface {
 	HasPostseasonStarted(year int64, startTime time.Time) (bool, error)
 	GetGamesBySeason(year int64, group Group) ([]Game, error)
 	TeamConferencesByYear(year int64) (map[int64]int64, error)
-	ConferenceMap() (map[Group]interface{}, error)
+	ConferenceMap() (ConferenceMapResult, error)
 }
 
 // SportInfo returns the sport this client is configured for.

--- a/internal/espn/team_info.go
+++ b/internal/espn/team_info.go
@@ -85,9 +85,10 @@ func (r TeamInfoESPN) validate() error {
 // SportURLs returns the ESPN URL templates for a given sport.
 // SportURLConfig holds ESPN URL templates for a sport.
 type SportURLConfig struct {
-	Schedule  string
-	GameStats string
-	TeamInfo  string
+	Schedule   string
+	GameStats  string
+	TeamInfo   string
+	Scoreboard string
 }
 
 // SportURLs returns the ESPN URL templates for a given sport.
@@ -95,15 +96,17 @@ func SportURLs(sport Sport) SportURLConfig {
 	switch sport {
 	case CollegeBasketball:
 		return SportURLConfig{
-			Schedule:  "https://cdn.espn.com/core/mens-college-basketball/schedule?xhr=1&render=false&userab=18",
-			GameStats: "https://cdn.espn.com/core/mens-college-basketball/playbyplay?gameId=%d&xhr=1&render=false&userab=18",
-			TeamInfo:  "https://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/teams?limit=1000",
+			Schedule:   "https://cdn.espn.com/core/mens-college-basketball/schedule?xhr=1&render=false&userab=18",
+			GameStats:  "https://cdn.espn.com/core/mens-college-basketball/playbyplay?gameId=%d&xhr=1&render=false&userab=18",
+			TeamInfo:   "https://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/teams?limit=1000",
+			Scoreboard: "https://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/scoreboard",
 		}
 	case CollegeFootball:
 		return SportURLConfig{
-			Schedule:  "https://cdn.espn.com/core/college-football/schedule?xhr=1&render=false&userab=18",
-			GameStats: "https://cdn.espn.com/core/college-football/playbyplay?gameId=%d&xhr=1&render=false&userab=18",
-			TeamInfo:  "https://site.api.espn.com/apis/site/v2/sports/football/college-football/teams?limit=1000",
+			Schedule:   "https://cdn.espn.com/core/college-football/schedule?xhr=1&render=false&userab=18",
+			GameStats:  "https://cdn.espn.com/core/college-football/playbyplay?gameId=%d&xhr=1&render=false&userab=18",
+			TeamInfo:   "https://site.api.espn.com/apis/site/v2/sports/football/college-football/teams?limit=1000",
+			Scoreboard: "https://site.api.espn.com/apis/site/v2/sports/football/college-football/scoreboard",
 		}
 	default:
 		panic(fmt.Sprintf("unknown sport: %q", sport))

--- a/internal/espn/team_info.go
+++ b/internal/espn/team_info.go
@@ -1,6 +1,9 @@
 package espn
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 //nolint:gochecknoglobals // overridden in tests
 var teamInfoURL = "https://site.api.espn.com/apis/site/v2/sports/football/college-football/teams?limit=1000"
@@ -80,19 +83,29 @@ func (r TeamInfoESPN) validate() error {
 }
 
 // SportURLs returns the ESPN URL templates for a given sport.
-func SportURLs(sport Sport) (string, string, string) {
+// SportURLConfig holds ESPN URL templates for a sport.
+type SportURLConfig struct {
+	Schedule  string
+	GameStats string
+	TeamInfo  string
+}
+
+// SportURLs returns the ESPN URL templates for a given sport.
+func SportURLs(sport Sport) SportURLConfig {
 	switch sport {
 	case CollegeBasketball:
-		return "https://cdn.espn.com/core/mens-college-basketball/schedule?xhr=1&render=false&userab=18",
-			"https://cdn.espn.com/core/mens-college-basketball/playbyplay?gameId=%d&xhr=1&render=false&userab=18",
-			"https://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/teams?limit=1000"
+		return SportURLConfig{
+			Schedule:  "https://cdn.espn.com/core/mens-college-basketball/schedule?xhr=1&render=false&userab=18",
+			GameStats: "https://cdn.espn.com/core/mens-college-basketball/playbyplay?gameId=%d&xhr=1&render=false&userab=18",
+			TeamInfo:  "https://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/teams?limit=1000",
+		}
 	case CollegeFootball:
-		return "https://cdn.espn.com/core/college-football/schedule?xhr=1&render=false&userab=18",
-			"https://cdn.espn.com/core/college-football/playbyplay?gameId=%d&xhr=1&render=false&userab=18",
-			"https://site.api.espn.com/apis/site/v2/sports/football/college-football/teams?limit=1000"
+		return SportURLConfig{
+			Schedule:  "https://cdn.espn.com/core/college-football/schedule?xhr=1&render=false&userab=18",
+			GameStats: "https://cdn.espn.com/core/college-football/playbyplay?gameId=%d&xhr=1&render=false&userab=18",
+			TeamInfo:  "https://site.api.espn.com/apis/site/v2/sports/football/college-football/teams?limit=1000",
+		}
+	default:
+		panic(fmt.Sprintf("unknown sport: %q", sport))
 	}
-	// Default to football.
-	return "https://cdn.espn.com/core/college-football/schedule?xhr=1&render=false&userab=18",
-		"https://cdn.espn.com/core/college-football/playbyplay?gameId=%d&xhr=1&render=false&userab=18",
-		"https://site.api.espn.com/apis/site/v2/sports/football/college-football/teams?limit=1000"
 }

--- a/internal/espn/team_info.go
+++ b/internal/espn/team_info.go
@@ -6,10 +6,10 @@ import "errors"
 var teamInfoURL = "https://site.api.espn.com/apis/site/v2/sports/football/college-football/teams?limit=1000"
 
 type TeamInfoESPN struct {
-	Sports []Sport `json:"sports"`
+	Sports []TeamInfoSport `json:"sports"`
 }
 
-type Sport struct {
+type TeamInfoSport struct {
 	ID      int64    `json:"id,string"`
 	Leagues []League `json:"leagues"`
 	Name    string   `json:"name"`
@@ -77,4 +77,22 @@ func (r TeamInfoESPN) validate() error {
 		return errors.New("team info response missing teams")
 	}
 	return nil
+}
+
+// SportURLs returns the ESPN URL templates for a given sport.
+func SportURLs(sport Sport) (string, string, string) {
+	switch sport {
+	case CollegeBasketball:
+		return "https://cdn.espn.com/core/mens-college-basketball/schedule?xhr=1&render=false&userab=18",
+			"https://cdn.espn.com/core/mens-college-basketball/playbyplay?gameId=%d&xhr=1&render=false&userab=18",
+			"https://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/teams?limit=1000"
+	case CollegeFootball:
+		return "https://cdn.espn.com/core/college-football/schedule?xhr=1&render=false&userab=18",
+			"https://cdn.espn.com/core/college-football/playbyplay?gameId=%d&xhr=1&render=false&userab=18",
+			"https://site.api.espn.com/apis/site/v2/sports/football/college-football/teams?limit=1000"
+	}
+	// Default to football.
+	return "https://cdn.espn.com/core/college-football/schedule?xhr=1&render=false&userab=18",
+		"https://cdn.espn.com/core/college-football/playbyplay?gameId=%d&xhr=1&render=false&userab=18",
+		"https://site.api.espn.com/apis/site/v2/sports/football/college-football/teams?limit=1000"
 }

--- a/internal/espn/testdata_test.go
+++ b/internal/espn/testdata_test.go
@@ -197,7 +197,7 @@ func testGameInfoResponse() GameInfoESPN {
 // testTeamInfoResponse returns a populated TeamInfoESPN for testing.
 func testTeamInfoResponse() TeamInfoESPN {
 	return TeamInfoESPN{
-		Sports: []Sport{
+		Sports: []TeamInfoSport{
 			{
 				ID:   90,
 				Name: "Football",

--- a/internal/espn/testing_helpers.go
+++ b/internal/espn/testing_helpers.go
@@ -9,3 +9,11 @@ func SetTestURLs(scheduleURL, gameURL, teamURL string) func() {
 	teamInfoURL = teamURL
 	return func() { weekURL, gameStatsURL, teamInfoURL = orig[0], orig[1], orig[2] }
 }
+
+// SetTestScoreboardURL sets a test override on a Client's scoreboard URL.
+// Returns a restore function suitable for use with t.Cleanup().
+func SetTestScoreboardURL(c *Client, url string) func() {
+	orig := c.scoreboardURL
+	c.scoreboardURL = url
+	return func() { c.scoreboardURL = orig }
+}

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -21,7 +21,7 @@ type ParsedGameInfo struct {
 	PuntStats         []database.PuntStats
 }
 
-func GetGameStats(client *espn.Client, games []espn.Game) ([]*ParsedGameInfo, error) {
+func GetGameStats(client espn.SportClient, games []espn.Game) ([]*ParsedGameInfo, error) {
 	var parsedGameStats []*ParsedGameInfo
 
 	for _, game := range games {
@@ -32,7 +32,7 @@ func GetGameStats(client *espn.Client, games []espn.Game) ([]*ParsedGameInfo, er
 
 		parsedGameStats = append(parsedGameStats, gameStats)
 
-		time.Sleep(client.RateLimit)
+		time.Sleep(client.RateLimitDuration())
 	}
 
 	return parsedGameStats, nil
@@ -56,9 +56,9 @@ func combineGames(gamesLists [][]espn.Game) []espn.Game {
 
 // GetCurrentWeekGames fetches completed games for the current week across all
 // groups defined for the client's sport.
-func GetCurrentWeekGames(client *espn.Client) ([]espn.Game, error) {
+func GetCurrentWeekGames(client espn.SportClient) ([]espn.Game, error) {
 	var allGames [][]espn.Game
-	for _, group := range client.Sport.Groups() {
+	for _, group := range client.SportInfo().Groups() {
 		games, err := client.GetCurrentWeekGames(group)
 		if err != nil {
 			return nil, err
@@ -71,9 +71,9 @@ func GetCurrentWeekGames(client *espn.Client) ([]espn.Game, error) {
 
 // GetGamesForSeason fetches all completed games for a season across all groups
 // defined for the client's sport.
-func GetGamesForSeason(client *espn.Client, year int64) ([]espn.Game, error) {
+func GetGamesForSeason(client espn.SportClient, year int64) ([]espn.Game, error) {
 	var allGames [][]espn.Game
-	for _, group := range client.Sport.Groups() {
+	for _, group := range client.SportInfo().Groups() {
 		games, err := client.GetGamesBySeason(year, group)
 		if err != nil {
 			return nil, err
@@ -84,7 +84,7 @@ func GetGamesForSeason(client *espn.Client, year int64) ([]espn.Game, error) {
 	return combineGames(allGames), nil
 }
 
-func GetSingleGame(client *espn.Client, gameID int64) (*ParsedGameInfo, error) {
+func GetSingleGame(client espn.SportClient, gameID int64) (*ParsedGameInfo, error) {
 	res, err := client.GetGameStats(gameID)
 	if err != nil {
 		return nil, err
@@ -92,9 +92,9 @@ func GetSingleGame(client *espn.Client, gameID int64) (*ParsedGameInfo, error) {
 
 	parsedGame := &ParsedGameInfo{}
 	parsedGame.parseGameInfo(res)
-	parsedGame.GameInfo.Sport = client.Sport.SportDB()
+	parsedGame.GameInfo.Sport = client.SportInfo().SportDB()
 	parsedGame.parseTeamInfo(res)
-	if client.Sport == espn.CollegeFootball {
+	if client.SportInfo() == espn.CollegeFootball {
 		parsedGame.parsePlayerStats(res)
 	}
 

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -1,8 +1,6 @@
 package game
 
 import (
-	"time"
-
 	"github.com/robby-barton/stats-go/internal/database"
 	"github.com/robby-barton/stats-go/internal/espn"
 )
@@ -19,23 +17,6 @@ type ParsedGameInfo struct {
 	ReturnStats       []database.ReturnStats
 	KickStats         []database.KickStats
 	PuntStats         []database.PuntStats
-}
-
-func GetGameStats(client espn.SportClient, games []espn.Game) ([]*ParsedGameInfo, error) {
-	var parsedGameStats []*ParsedGameInfo
-
-	for _, game := range games {
-		gameStats, err := GetSingleGame(client, game.ID)
-		if err != nil {
-			return nil, err
-		}
-
-		parsedGameStats = append(parsedGameStats, gameStats)
-
-		time.Sleep(client.RateLimitDuration())
-	}
-
-	return parsedGameStats, nil
 }
 
 func combineGames(gamesLists [][]espn.Game) []espn.Game {

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -163,13 +163,13 @@ func TestGetSingleGame_Basketball(t *testing.T) {
 	)
 	t.Cleanup(restore)
 
-	client := &espn.Client{
+	client := &espn.BasketballClient{Client: &espn.Client{
 		MaxRetries:     2,
 		InitialBackoff: 10 * time.Millisecond,
 		RequestTimeout: 1 * time.Second,
 		RateLimit:      0,
 		Sport:          espn.CollegeBasketball,
-	}
+	}}
 
 	parsed, err := GetSingleGame(client, 2001)
 	if err != nil {
@@ -213,13 +213,13 @@ func TestGetCurrentWeekGames_Basketball(t *testing.T) {
 	)
 	t.Cleanup(restore)
 
-	client := &espn.Client{
+	client := &espn.BasketballClient{Client: &espn.Client{
 		MaxRetries:     2,
 		InitialBackoff: 10 * time.Millisecond,
 		RequestTimeout: 1 * time.Second,
 		RateLimit:      0,
 		Sport:          espn.CollegeBasketball,
-	}
+	}}
 
 	games, err := GetCurrentWeekGames(client)
 	if err != nil {

--- a/internal/ranking/ranking.go
+++ b/internal/ranking/ranking.go
@@ -8,32 +8,49 @@ import (
 	"gorm.io/gorm"
 )
 
+const (
+	sportFootball   = "cfb"
+	sportBasketball = "cbb"
+)
+
 type Ranker struct {
 	DB    *gorm.DB
 	Year  int64
 	Week  int64
 	Fcs   bool
-	Sport string // "cfb" or "cbb"
+	Sport string // sportFootball or sportBasketball
 
 	startTime  time.Time
 	postseason bool
 }
 
+type sportParams struct {
+	RequiredGames int
+	YearsBack     int64
+	MOVCaps       []int64
+}
+
 // sportConfig returns ranking constants appropriate for the sport.
-func (r *Ranker) sportConfig() (int, int64, []int64) {
+func (r *Ranker) sportConfig() sportParams {
 	switch r.Sport {
-	case "cbb":
-		return 25, 1, []int64{1, 20}
-	default: // cfb
-		return 12, 2, []int64{1, 30}
+	case sportBasketball:
+		return sportParams{RequiredGames: 25, YearsBack: 1, MOVCaps: []int64{1, 20}}
+	case sportFootball, "":
+		return sportParams{RequiredGames: 12, YearsBack: 2, MOVCaps: []int64{1, 30}}
+	default:
+		panic(fmt.Sprintf("unknown sport: %q", r.Sport))
 	}
 }
 
 func (r *Ranker) sportFilter() string {
-	if r.Sport == "" {
-		return "cfb"
+	switch r.Sport {
+	case sportFootball, sportBasketball:
+		return r.Sport
+	case "":
+		return sportFootball
+	default:
+		panic(fmt.Sprintf("unknown sport: %q", r.Sport))
 	}
-	return r.Sport
 }
 
 type Team struct {

--- a/internal/ranking/ranking.go
+++ b/internal/ranking/ranking.go
@@ -35,7 +35,7 @@ func (r *Ranker) sportConfig() sportParams {
 	switch r.Sport {
 	case sportBasketball:
 		return sportParams{RequiredGames: 25, YearsBack: 1, MOVCaps: []int64{1, 20}}
-	case sportFootball, "":
+	case sportFootball:
 		return sportParams{RequiredGames: 12, YearsBack: 2, MOVCaps: []int64{1, 30}}
 	default:
 		panic(fmt.Sprintf("unknown sport: %q", r.Sport))
@@ -46,8 +46,6 @@ func (r *Ranker) sportFilter() string {
 	switch r.Sport {
 	case sportFootball, sportBasketball:
 		return r.Sport
-	case "":
-		return sportFootball
 	default:
 		panic(fmt.Sprintf("unknown sport: %q", r.Sport))
 	}

--- a/internal/ranking/ranking.go
+++ b/internal/ranking/ranking.go
@@ -9,13 +9,31 @@ import (
 )
 
 type Ranker struct {
-	DB   *gorm.DB
-	Year int64
-	Week int64
-	Fcs  bool
+	DB    *gorm.DB
+	Year  int64
+	Week  int64
+	Fcs   bool
+	Sport string // "cfb" or "cbb"
 
 	startTime  time.Time
 	postseason bool
+}
+
+// sportConfig returns ranking constants appropriate for the sport.
+func (r *Ranker) sportConfig() (int, int64, []int64) {
+	switch r.Sport {
+	case "cbb":
+		return 25, 1, []int64{1, 20}
+	default: // cfb
+		return 12, 2, []int64{1, 30}
+	}
+}
+
+func (r *Ranker) sportFilter() string {
+	if r.Sport == "" {
+		return "cfb"
+	}
+	return r.Sport
 }
 
 type Team struct {

--- a/internal/ranking/ranking_basketball_test.go
+++ b/internal/ranking/ranking_basketball_test.go
@@ -1,0 +1,226 @@
+package ranking
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/robby-barton/stats-go/internal/database"
+)
+
+// seedBasketballData inserts 5 basketball teams (all FBS=1) and 6 games across
+// 2 weeks for the 2024 season. Also inserts one football game to confirm
+// sport filtering excludes it.
+func seedBasketballData(t *testing.T, db *gorm.DB) {
+	t.Helper()
+
+	teamNames := []database.TeamName{
+		{TeamID: 101, Name: "Hoops A", Sport: "cbb"},
+		{TeamID: 102, Name: "Hoops B", Sport: "cbb"},
+		{TeamID: 103, Name: "Hoops C", Sport: "cbb"},
+		{TeamID: 104, Name: "Hoops D", Sport: "cbb"},
+		{TeamID: 105, Name: "Hoops E", Sport: "cbb"},
+	}
+	if err := db.Create(&teamNames).Error; err != nil {
+		t.Fatalf("seed basketball team_names: %v", err)
+	}
+
+	teamSeasons := []database.TeamSeason{
+		{TeamID: 101, Year: 2024, FBS: 1, Conf: "Big East", Sport: "cbb"},
+		{TeamID: 102, Year: 2024, FBS: 1, Conf: "Big East", Sport: "cbb"},
+		{TeamID: 103, Year: 2024, FBS: 1, Conf: "ACC", Sport: "cbb"},
+		{TeamID: 104, Year: 2024, FBS: 1, Conf: "ACC", Sport: "cbb"},
+		{TeamID: 105, Year: 2024, FBS: 1, Conf: "Big 12", Sport: "cbb"},
+	}
+	if err := db.Create(&teamSeasons).Error; err != nil {
+		t.Fatalf("seed basketball team_seasons: %v", err)
+	}
+
+	base := time.Date(2024, 1, 2, 19, 0, 0, 0, time.UTC) // Tuesday
+	week := 7 * 24 * time.Hour
+
+	games := []database.Game{
+		// Week 1
+		{GameID: 3001, Season: 2024, Week: 1, HomeID: 101, AwayID: 102,
+			HomeScore: 78, AwayScore: 65, ConfGame: true, Sport: "cbb", StartTime: base},
+		{GameID: 3002, Season: 2024, Week: 1, HomeID: 103, AwayID: 104,
+			HomeScore: 70, AwayScore: 68, ConfGame: true, Sport: "cbb", StartTime: base.Add(time.Hour)},
+		{GameID: 3003, Season: 2024, Week: 1, HomeID: 105, AwayID: 101,
+			HomeScore: 60, AwayScore: 72, Sport: "cbb", StartTime: base.Add(2 * time.Hour)},
+		// Week 2
+		{GameID: 3004, Season: 2024, Week: 2, HomeID: 101, AwayID: 103,
+			HomeScore: 80, AwayScore: 75, Sport: "cbb", StartTime: base.Add(week)},
+		{GameID: 3005, Season: 2024, Week: 2, HomeID: 102, AwayID: 104,
+			HomeScore: 66, AwayScore: 64, Sport: "cbb", StartTime: base.Add(week + time.Hour)},
+		{GameID: 3006, Season: 2024, Week: 2, HomeID: 105, AwayID: 103,
+			HomeScore: 55, AwayScore: 55, Sport: "cbb", StartTime: base.Add(week + 2*time.Hour)},
+	}
+	if err := db.Create(&games).Error; err != nil {
+		t.Fatalf("seed basketball games: %v", err)
+	}
+
+	// Football game — should be excluded by sport filter
+	footballGame := database.Game{
+		GameID: 9001, Season: 2024, Week: 1, HomeID: 101, AwayID: 102,
+		HomeScore: 35, AwayScore: 10, Sport: "cfb",
+		StartTime: base,
+	}
+	if err := db.Create(&footballGame).Error; err != nil {
+		t.Fatalf("seed football game: %v", err)
+	}
+}
+
+func TestSetGlobals_Basketball(t *testing.T) {
+	db := setupTestDB(t)
+	seedBasketballData(t, db)
+
+	// Also seed football data to ensure it's ignored
+	seedTestData(t, db)
+
+	r := &Ranker{DB: db, Sport: "cbb"}
+	if err := r.setGlobals(); err != nil {
+		t.Fatalf("setGlobals: %v", err)
+	}
+
+	if r.Year != 2024 {
+		t.Errorf("Year = %d, want 2024", r.Year)
+	}
+	// Latest basketball game is week 2, so Week should be 3
+	if r.Week != 3 {
+		t.Errorf("Week = %d, want 3", r.Week)
+	}
+}
+
+func TestCreateTeamList_Basketball(t *testing.T) {
+	db := setupTestDB(t)
+	seedBasketballData(t, db)
+
+	r := &Ranker{DB: db, Year: 2024, Week: 3, Sport: "cbb"}
+
+	// All basketball teams have FBS=1
+	teamList, err := r.createTeamList(1)
+	if err != nil {
+		t.Fatalf("createTeamList(1): %v", err)
+	}
+	if len(teamList) != 5 {
+		t.Fatalf("len(teamList) = %d, want 5", len(teamList))
+	}
+
+	// No FCS in basketball — createTeamList(0) should return empty
+	teamListFCS, err := r.createTeamList(0)
+	if err != nil {
+		t.Fatalf("createTeamList(0): %v", err)
+	}
+	if len(teamListFCS) != 0 {
+		t.Errorf("len(teamList FCS) = %d, want 0", len(teamListFCS))
+	}
+}
+
+func TestRecord_Basketball(t *testing.T) {
+	db := setupTestDB(t)
+	seedBasketballData(t, db)
+
+	r := &Ranker{
+		DB:        db,
+		Year:      2024,
+		Sport:     "cbb",
+		startTime: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC), // after all games
+	}
+
+	teamList := TeamList{
+		101: &Team{Name: "Hoops A"},
+		102: &Team{Name: "Hoops B"},
+		103: &Team{Name: "Hoops C"},
+		104: &Team{Name: "Hoops D"},
+		105: &Team{Name: "Hoops E"},
+	}
+
+	if err := r.record(teamList); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+
+	// Hoops A: 3W-0L (3001, 3003 as away win, 3004)
+	assertRecord(t, "Hoops A", teamList[101], 3, 0, 0, 4.0/5.0)
+
+	// Hoops B: 1W-1L (win: 3005, loss: 3001)
+	assertRecord(t, "Hoops B", teamList[102], 1, 1, 0, 2.0/4.0)
+
+	// Hoops E: 0W-1L-1T (loss: 3003, tie: 3006)
+	assertRecord(t, "Hoops E", teamList[105], 0, 1, 1, 1.5/4.0)
+}
+
+func TestSRS_Basketball(t *testing.T) {
+	db := setupTestDB(t)
+	seedBasketballData(t, db)
+
+	r := &Ranker{
+		DB:        db,
+		Year:      2024,
+		Sport:     "cbb",
+		startTime: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+	}
+
+	teamList := TeamList{
+		101: &Team{Name: "Hoops A"},
+		102: &Team{Name: "Hoops B"},
+		103: &Team{Name: "Hoops C"},
+		104: &Team{Name: "Hoops D"},
+		105: &Team{Name: "Hoops E"},
+	}
+
+	if err := r.srs(teamList); err != nil {
+		t.Fatalf("srs: %v", err)
+	}
+
+	// Hoops A (3-0) should have highest SRS
+	if teamList[101].SRS <= teamList[104].SRS {
+		t.Errorf("Hoops A SRS (%f) should be > Hoops D SRS (%f)", teamList[101].SRS, teamList[104].SRS)
+	}
+
+	// All SRSNorm should be in [0, 1]
+	for id, team := range teamList {
+		if team.SRSNorm < 0 || team.SRSNorm > 1 {
+			t.Errorf("team %d SRSNorm = %f, want [0,1]", id, team.SRSNorm)
+		}
+	}
+
+	// Best team should have SRSNorm = 1.0
+	if math.Abs(teamList[101].SRSNorm-1.0) > 0.001 {
+		t.Errorf("Hoops A SRSNorm = %f, want 1.0", teamList[101].SRSNorm)
+	}
+}
+
+func TestCalculateRanking_Basketball(t *testing.T) {
+	db := setupTestDB(t)
+	seedBasketballData(t, db)
+
+	r := &Ranker{
+		DB:    db,
+		Year:  2024,
+		Sport: "cbb",
+	}
+
+	teamList, err := r.CalculateRanking()
+	if err != nil {
+		t.Fatalf("CalculateRanking: %v", err)
+	}
+
+	// All 5 basketball teams should be included (all FBS=1 for cbb)
+	if len(teamList) != 5 {
+		t.Fatalf("len(teamList) = %d, want 5", len(teamList))
+	}
+
+	// Hoops A (3-0) should be rank 1
+	if teamList[101].FinalRank != 1 {
+		t.Errorf("Hoops A FinalRank = %d, want 1", teamList[101].FinalRank)
+	}
+
+	// All ranks should be valid
+	for id, team := range teamList {
+		if team.FinalRank < 1 || team.FinalRank > 5 {
+			t.Errorf("team %d FinalRank = %d, want [1,5]", id, team.FinalRank)
+		}
+	}
+}

--- a/internal/ranking/rating_test.go
+++ b/internal/ranking/rating_test.go
@@ -13,6 +13,7 @@ func TestSRS_BasicRanking(t *testing.T) {
 	r := &Ranker{
 		DB:        db,
 		Year:      2023,
+		Sport:     sportFootball,
 		startTime: time.Date(2023, 10, 10, 0, 0, 0, 0, time.UTC),
 	}
 
@@ -55,6 +56,7 @@ func TestSRS_RankAssignment(t *testing.T) {
 	r := &Ranker{
 		DB:        db,
 		Year:      2023,
+		Sport:     sportFootball,
 		startTime: time.Date(2023, 10, 10, 0, 0, 0, 0, time.UTC),
 	}
 
@@ -89,6 +91,7 @@ func TestSOS_BasicRanking(t *testing.T) {
 	r := &Ranker{
 		DB:        db,
 		Year:      2023,
+		Sport:     sportFootball,
 		startTime: time.Date(2023, 10, 10, 0, 0, 0, 0, time.UTC),
 	}
 
@@ -123,9 +126,10 @@ func TestCalculateRanking_FullPipeline(t *testing.T) {
 	seedTestData(t, db)
 
 	r := &Ranker{
-		DB:   db,
-		Year: 2023,
-		Week: 6,
+		DB:    db,
+		Year:  2023,
+		Week:  6,
+		Sport: sportFootball,
 	}
 
 	// Need to set startTime manually since setGlobals queries for week 6

--- a/internal/ranking/record.go
+++ b/internal/ranking/record.go
@@ -5,14 +5,16 @@ import (
 )
 
 func (r *Ranker) record(teamList TeamList) error {
+	sport := r.sportFilter()
+
 	var games []database.Game
-	if err := r.DB.Where("season = ? and start_time <= ?", r.Year, r.startTime).
+	if err := r.DB.Where("sport = ? and season = ? and start_time <= ?", sport, r.Year, r.startTime).
 		Find(&games).Error; err != nil {
 		return err
 	}
 
 	var allTeams []int64
-	if err := r.DB.Model(database.TeamSeason{}).Where("year = ?", r.Year).
+	if err := r.DB.Model(database.TeamSeason{}).Where("sport = ? and year = ?", sport, r.Year).
 		Pluck("team_id", &allTeams).Error; err != nil {
 		return err
 	}

--- a/internal/ranking/record_test.go
+++ b/internal/ranking/record_test.go
@@ -13,6 +13,7 @@ func TestRecord_BasicRecords(t *testing.T) {
 	r := &Ranker{
 		DB:        db,
 		Year:      2023,
+		Sport:     sportFootball,
 		startTime: time.Date(2023, 10, 10, 0, 0, 0, 0, time.UTC), // after all games
 	}
 
@@ -52,6 +53,7 @@ func TestRecord_PartialSeason(t *testing.T) {
 	r := &Ranker{
 		DB:        db,
 		Year:      2023,
+		Sport:     sportFootball,
 		startTime: time.Date(2023, 9, 18, 0, 0, 0, 0, time.UTC),
 	}
 
@@ -81,6 +83,7 @@ func TestRecord_TieHandling(t *testing.T) {
 	r := &Ranker{
 		DB:        db,
 		Year:      2023,
+		Sport:     sportFootball,
 		startTime: time.Date(2023, 10, 10, 0, 0, 0, 0, time.UTC),
 	}
 

--- a/internal/ranking/setup.go
+++ b/internal/ranking/setup.go
@@ -14,13 +14,10 @@ func (r *Ranker) setup() (TeamList, error) {
 	var teamList TeamList
 	var err error
 
-	// Basketball has no FBS/FCS split — all D1 teams are FBS=1
-	switch {
-	case r.Sport == "cbb":
-		teamList, err = r.createTeamList(1)
-	case r.Fcs:
+	// FCS ranking only applies to football; basketball has no division split.
+	if r.Fcs && r.Sport != sportBasketball {
 		teamList, err = r.createTeamList(0)
-	default:
+	} else {
 		teamList, err = r.createTeamList(1)
 	}
 	if err != nil {
@@ -99,7 +96,7 @@ func (r *Ranker) createTeamList(findFbs int64) (TeamList, error) {
 
 	if err := r.DB.Model(&database.TeamSeason{}).
 		Select("team_names.team_id, team_names.name, team_seasons.conf").
-		Joins("left join team_names on team_seasons.team_id = team_names.team_id").
+		Joins("left join team_names on team_seasons.team_id = team_names.team_id and team_seasons.sport = team_names.sport").
 		Where("team_seasons.fbs = ? and team_seasons.year = ? and team_seasons.sport = ?",
 			findFbs, r.Year, r.sportFilter()).
 		Scan(&teams).Error; err != nil {

--- a/internal/ranking/setup.go
+++ b/internal/ranking/setup.go
@@ -13,23 +13,30 @@ func (r *Ranker) setup() (TeamList, error) {
 
 	var teamList TeamList
 	var err error
-	if r.Fcs {
-		if teamList, err = r.createTeamList(0); err != nil {
-			return nil, err
-		}
-	} else {
-		if teamList, err = r.createTeamList(1); err != nil {
-			return nil, err
-		}
+
+	// Basketball has no FBS/FCS split — all D1 teams are FBS=1
+	switch {
+	case r.Sport == "cbb":
+		teamList, err = r.createTeamList(1)
+	case r.Fcs:
+		teamList, err = r.createTeamList(0)
+	default:
+		teamList, err = r.createTeamList(1)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	return teamList, nil
 }
 
 func (r *Ranker) setGlobals() error {
+	sport := r.sportFilter()
+
 	if r.Year == 0 {
 		var year int64
 		if err := r.DB.Model(database.TeamSeason{}).
+			Where("sport = ?", sport).
 			Select("max(year) as year").Pluck("year", &year).Error; err != nil {
 			return err
 		}
@@ -39,7 +46,7 @@ func (r *Ranker) setGlobals() error {
 	var game database.Game
 	if r.Week > 0 {
 		if err := r.DB.
-			Where("season = ? and week = ? and postseason = 0", r.Year, r.Week).
+			Where("sport = ? and season = ? and week = ? and postseason = 0", sport, r.Year, r.Week).
 			Order("start_time asc").
 			Limit(1).
 			Find(&game).Error; err != nil {
@@ -56,7 +63,7 @@ func (r *Ranker) setGlobals() error {
 
 	if game == (database.Game{}) {
 		if err := r.DB.
-			Where("season <= ?", r.Year).
+			Where("sport = ? and season <= ?", sport, r.Year).
 			Order("start_time desc").
 			Limit(1).
 			Find(&game).Error; err != nil {
@@ -93,7 +100,8 @@ func (r *Ranker) createTeamList(findFbs int64) (TeamList, error) {
 	if err := r.DB.Model(&database.TeamSeason{}).
 		Select("team_names.team_id, team_names.name, team_seasons.conf").
 		Joins("left join team_names on team_seasons.team_id = team_names.team_id").
-		Where("team_seasons.fbs = ? and team_seasons.year = ?", findFbs, r.Year).
+		Where("team_seasons.fbs = ? and team_seasons.year = ? and team_seasons.sport = ?",
+			findFbs, r.Year, r.sportFilter()).
 		Scan(&teams).Error; err != nil {
 		return nil, err
 	}

--- a/internal/ranking/setup.go
+++ b/internal/ranking/setup.go
@@ -96,7 +96,7 @@ func (r *Ranker) createTeamList(findFbs int64) (TeamList, error) {
 
 	if err := r.DB.Model(&database.TeamSeason{}).
 		Select("team_names.team_id, team_names.name, team_seasons.conf").
-		Joins("left join team_names on team_seasons.team_id = team_names.team_id and team_seasons.sport = team_names.sport").
+		Joins("join team_names on team_seasons.team_id = team_names.team_id and team_seasons.sport = team_names.sport").
 		Where("team_seasons.fbs = ? and team_seasons.year = ? and team_seasons.sport = ?",
 			findFbs, r.Year, r.sportFilter()).
 		Scan(&teams).Error; err != nil {

--- a/internal/ranking/setup_test.go
+++ b/internal/ranking/setup_test.go
@@ -11,7 +11,7 @@ func TestSetGlobals_DefaultYear(t *testing.T) {
 	db := setupTestDB(t)
 	seedTestData(t, db)
 
-	r := &Ranker{DB: db}
+	r := &Ranker{DB: db, Sport: sportFootball}
 	if err := r.setGlobals(); err != nil {
 		t.Fatalf("setGlobals: %v", err)
 	}
@@ -25,7 +25,7 @@ func TestSetGlobals_WeekSpecified(t *testing.T) {
 	db := setupTestDB(t)
 	seedTestData(t, db)
 
-	r := &Ranker{DB: db, Year: 2023, Week: 3}
+	r := &Ranker{DB: db, Year: 2023, Week: 3, Sport: sportFootball}
 	if err := r.setGlobals(); err != nil {
 		t.Fatalf("setGlobals: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestSetGlobals_WeekZero(t *testing.T) {
 	db := setupTestDB(t)
 	seedTestData(t, db)
 
-	r := &Ranker{DB: db, Year: 2023}
+	r := &Ranker{DB: db, Year: 2023, Sport: sportFootball}
 	if err := r.setGlobals(); err != nil {
 		t.Fatalf("setGlobals: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestSetGlobals_Postseason(t *testing.T) {
 		t.Fatalf("create postseason game: %v", err)
 	}
 
-	r := &Ranker{DB: db, Year: 2023}
+	r := &Ranker{DB: db, Year: 2023, Sport: sportFootball}
 	if err := r.setGlobals(); err != nil {
 		t.Fatalf("setGlobals: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestCreateTeamList_FBS(t *testing.T) {
 	db := setupTestDB(t)
 	seedTestData(t, db)
 
-	r := &Ranker{DB: db, Year: 2023, Week: 6}
+	r := &Ranker{DB: db, Year: 2023, Week: 6, Sport: sportFootball}
 	teamList, err := r.createTeamList(1)
 	if err != nil {
 		t.Fatalf("createTeamList: %v", err)
@@ -130,7 +130,7 @@ func TestCreateTeamList_FCS(t *testing.T) {
 	db := setupTestDB(t)
 	seedTestData(t, db)
 
-	r := &Ranker{DB: db, Year: 2023, Week: 6}
+	r := &Ranker{DB: db, Year: 2023, Week: 6, Sport: sportFootball}
 	teamList, err := r.createTeamList(0)
 	if err != nil {
 		t.Fatalf("createTeamList: %v", err)

--- a/internal/ranking/testhelper_test.go
+++ b/internal/ranking/testhelper_test.go
@@ -36,27 +36,27 @@ func seedTestData(t *testing.T, db *gorm.DB) {
 
 	// 5 teams: 4 FBS, 1 FCS
 	teamNames := []database.TeamName{
-		{TeamID: 1, Name: "Alpha"},
-		{TeamID: 2, Name: "Beta"},
-		{TeamID: 3, Name: "Gamma"},
-		{TeamID: 4, Name: "Delta"},
-		{TeamID: 5, Name: "Epsilon"},
+		{TeamID: 1, Name: "Alpha", Sport: "cfb"},
+		{TeamID: 2, Name: "Beta", Sport: "cfb"},
+		{TeamID: 3, Name: "Gamma", Sport: "cfb"},
+		{TeamID: 4, Name: "Delta", Sport: "cfb"},
+		{TeamID: 5, Name: "Epsilon", Sport: "cfb"},
 	}
 	if err := db.Create(&teamNames).Error; err != nil {
 		t.Fatalf("seed team_names: %v", err)
 	}
 
 	teamSeasons := []database.TeamSeason{
-		{TeamID: 1, Year: 2023, FBS: 1, Conf: "SEC"},
-		{TeamID: 2, Year: 2023, FBS: 1, Conf: "SEC"},
-		{TeamID: 3, Year: 2023, FBS: 1, Conf: "Big Ten"},
-		{TeamID: 4, Year: 2023, FBS: 1, Conf: "Big Ten"},
-		{TeamID: 5, Year: 2023, FBS: 0, Conf: "FCS"},
+		{TeamID: 1, Year: 2023, FBS: 1, Conf: "SEC", Sport: "cfb"},
+		{TeamID: 2, Year: 2023, FBS: 1, Conf: "SEC", Sport: "cfb"},
+		{TeamID: 3, Year: 2023, FBS: 1, Conf: "Big Ten", Sport: "cfb"},
+		{TeamID: 4, Year: 2023, FBS: 1, Conf: "Big Ten", Sport: "cfb"},
+		{TeamID: 5, Year: 2023, FBS: 0, Conf: "FCS", Sport: "cfb"},
 		// Historical team_seasons for 2022
-		{TeamID: 1, Year: 2022, FBS: 1, Conf: "SEC"},
-		{TeamID: 2, Year: 2022, FBS: 1, Conf: "SEC"},
-		{TeamID: 3, Year: 2022, FBS: 1, Conf: "Big Ten"},
-		{TeamID: 4, Year: 2022, FBS: 1, Conf: "Big Ten"},
+		{TeamID: 1, Year: 2022, FBS: 1, Conf: "SEC", Sport: "cfb"},
+		{TeamID: 2, Year: 2022, FBS: 1, Conf: "SEC", Sport: "cfb"},
+		{TeamID: 3, Year: 2022, FBS: 1, Conf: "Big Ten", Sport: "cfb"},
+		{TeamID: 4, Year: 2022, FBS: 1, Conf: "Big Ten", Sport: "cfb"},
 	}
 	if err := db.Create(&teamSeasons).Error; err != nil {
 		t.Fatalf("seed team_seasons: %v", err)
@@ -70,53 +70,53 @@ func seedTestData(t *testing.T, db *gorm.DB) {
 		// 2023 season games
 		{
 			GameID: 1001, Season: 2023, Week: 1, HomeID: 1, AwayID: 2,
-			HomeScore: 28, AwayScore: 14, ConfGame: true, StartTime: base,
+			HomeScore: 28, AwayScore: 14, ConfGame: true, Sport: "cfb", StartTime: base,
 		},
 		{
 			GameID: 1002, Season: 2023, Week: 1, HomeID: 3, AwayID: 4,
-			HomeScore: 21, AwayScore: 10, ConfGame: true, StartTime: base.Add(time.Hour),
+			HomeScore: 21, AwayScore: 10, ConfGame: true, Sport: "cfb", StartTime: base.Add(time.Hour),
 		},
 		{
 			GameID: 1003, Season: 2023, Week: 2, HomeID: 1, AwayID: 3,
-			HomeScore: 35, AwayScore: 17, StartTime: base.Add(week),
+			HomeScore: 35, AwayScore: 17, Sport: "cfb", StartTime: base.Add(week),
 		},
 		{
 			GameID: 1004, Season: 2023, Week: 2, HomeID: 2, AwayID: 4,
-			HomeScore: 24, AwayScore: 21, ConfGame: true, StartTime: base.Add(week + time.Hour),
+			HomeScore: 24, AwayScore: 21, ConfGame: true, Sport: "cfb", StartTime: base.Add(week + time.Hour),
 		},
 		{
 			GameID: 1005, Season: 2023, Week: 3, HomeID: 1, AwayID: 4,
-			HomeScore: 42, AwayScore: 7, StartTime: base.Add(2 * week),
+			HomeScore: 42, AwayScore: 7, Sport: "cfb", StartTime: base.Add(2 * week),
 		},
 		{
 			GameID: 1006, Season: 2023, Week: 3, HomeID: 2, AwayID: 3,
-			HomeScore: 17, AwayScore: 14, StartTime: base.Add(2*week + time.Hour),
+			HomeScore: 17, AwayScore: 14, Sport: "cfb", StartTime: base.Add(2*week + time.Hour),
 		},
 		{
 			GameID: 1007, Season: 2023, Week: 4, HomeID: 3, AwayID: 2,
-			HomeScore: 28, AwayScore: 21, StartTime: base.Add(3 * week),
+			HomeScore: 28, AwayScore: 21, Sport: "cfb", StartTime: base.Add(3 * week),
 		},
 		{
 			GameID: 1008, Season: 2023, Week: 4, HomeID: 1, AwayID: 5,
-			HomeScore: 31, AwayScore: 10, StartTime: base.Add(3*week + time.Hour),
+			HomeScore: 31, AwayScore: 10, Sport: "cfb", StartTime: base.Add(3*week + time.Hour),
 		},
 		{
 			GameID: 1009, Season: 2023, Week: 5, HomeID: 4, AwayID: 3,
-			HomeScore: 14, AwayScore: 14, StartTime: base.Add(4 * week),
+			HomeScore: 14, AwayScore: 14, Sport: "cfb", StartTime: base.Add(4 * week),
 		},
 		{
 			GameID: 1010, Season: 2023, Week: 5, HomeID: 2, AwayID: 5,
-			HomeScore: 35, AwayScore: 7, StartTime: base.Add(4*week + time.Hour),
+			HomeScore: 35, AwayScore: 7, Sport: "cfb", StartTime: base.Add(4*week + time.Hour),
 		},
 		// 2022 historical games
 		{
 			GameID: 901, Season: 2022, Week: 1, HomeID: 1, AwayID: 2,
-			HomeScore: 24, AwayScore: 17,
+			HomeScore: 24, AwayScore: 17, Sport: "cfb",
 			StartTime: time.Date(2022, 9, 6, 19, 0, 0, 0, time.UTC),
 		},
 		{
 			GameID: 902, Season: 2022, Week: 2, HomeID: 3, AwayID: 4,
-			HomeScore: 20, AwayScore: 13,
+			HomeScore: 20, AwayScore: 13, Sport: "cfb",
 			StartTime: time.Date(2022, 9, 13, 19, 0, 0, 0, time.UTC),
 		},
 	}

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -1,8 +1,6 @@
 package team
 
 import (
-	"fmt"
-
 	"github.com/robby-barton/stats-go/internal/espn"
 )
 
@@ -25,7 +23,7 @@ type ParsedTeamInfo struct {
 	Slug             string
 }
 
-func GetTeamInfo(client *espn.Client) ([]ParsedTeamInfo, error) {
+func GetTeamInfo(client espn.SportClient) ([]ParsedTeamInfo, error) {
 	var parsedTeamInfo []ParsedTeamInfo
 
 	res, err := client.GetTeamInfo()
@@ -52,21 +50,17 @@ func GetTeamInfo(client *espn.Client) ([]ParsedTeamInfo, error) {
 		teamInfo.ShortDisplayName = team.ShortDisplayName
 		teamInfo.Slug = team.Slug
 
-		if len(team.Logos) > 2 {
-			return nil, fmt.Errorf("too many logos for %d", team.ID)
-		}
-
 		for _, logo := range team.Logos {
-			theme := ""
+			isDark := false
 			for i := len(logo.Rel) - 1; i >= 0; i-- {
 				if logo.Rel[i] == dark {
-					theme = dark
+					isDark = true
 					break
 				}
 			}
-			if theme == dark {
+			if isDark && teamInfo.LogoDark == "" {
 				teamInfo.LogoDark = logo.Href
-			} else {
+			} else if !isDark && teamInfo.Logo == "" {
 				teamInfo.Logo = logo.Href
 			}
 		}

--- a/internal/updater/testhelper_test.go
+++ b/internal/updater/testhelper_test.go
@@ -148,8 +148,8 @@ func fixtureScheduleResponse() espn.GameScheduleESPN {
 					},
 				},
 			},
-			Parameters: espn.Parameters{Week: 1, Year: 2023, SeasonType: 2, Group: 80},
-			Defaults:   espn.Parameters{Week: 1, Year: 2023, SeasonType: 2, Group: 80},
+			Parameters: espn.Parameters{Week: 1, Year: 2023, SeasonType: 2, Group: espn.FlexInt64(80)},
+			Defaults:   espn.Parameters{Week: 1, Year: 2023, SeasonType: 2, Group: espn.FlexInt64(80)},
 			Calendar: []espn.Calendar{
 				{
 					StartDate:  "2023-08-26T07:00Z",
@@ -171,9 +171,9 @@ func fixtureScheduleResponse() espn.GameScheduleESPN {
 			},
 			ConferenceAPI: espn.ConferenceAPI{
 				Conferences: []espn.Conference{
-					{GroupID: 100, Name: "Southeastern Conference", ShortName: "SEC", ParentGroupID: 80},
-					{GroupID: 200, Name: "Big Ten Conference", ShortName: "Big Ten", ParentGroupID: 80},
-					{GroupID: 300, Name: "Missouri Valley", ShortName: "MVFC", ParentGroupID: 81},
+					{GroupID: 100, Name: "Southeastern Conference", ShortName: "SEC", ParentGroupID: espn.FlexInt64(80)},
+					{GroupID: 200, Name: "Big Ten Conference", ShortName: "Big Ten", ParentGroupID: espn.FlexInt64(80)},
+					{GroupID: 300, Name: "Missouri Valley", ShortName: "MVFC", ParentGroupID: espn.FlexInt64(81)},
 				},
 			},
 		},
@@ -473,20 +473,19 @@ func newTestUpdater(t *testing.T, scoreOverride map[int64][2]int64) (*Updater, *
 	)
 	t.Cleanup(restore)
 
-	client := &espn.Client{
+	client := &espn.FootballClient{Client: &espn.Client{
 		MaxRetries:     2,
 		InitialBackoff: 10 * time.Millisecond,
 		RequestTimeout: 5 * time.Second,
 		RateLimit:      0,
 		Sport:          espn.CollegeFootball,
-	}
+	}}
 
 	u := &Updater{
 		DB:     db,
 		Logger: zap.NewNop().Sugar(),
 		Writer: cw,
 		ESPN:   client,
-		Sport:  espn.CollegeFootball,
 	}
 
 	return u, cw

--- a/internal/updater/testhelper_test.go
+++ b/internal/updater/testhelper_test.go
@@ -341,7 +341,7 @@ func newGameInfo(
 
 func fixtureTeamInfoResponse() espn.TeamInfoESPN {
 	return espn.TeamInfoESPN{
-		Sports: []espn.Sport{{
+		Sports: []espn.TeamInfoSport{{
 			ID:   90,
 			Name: "Football",
 			Slug: "football",
@@ -478,6 +478,7 @@ func newTestUpdater(t *testing.T, scoreOverride map[int64][2]int64) (*Updater, *
 		InitialBackoff: 10 * time.Millisecond,
 		RequestTimeout: 5 * time.Second,
 		RateLimit:      0,
+		Sport:          espn.CollegeFootball,
 	}
 
 	u := &Updater{
@@ -485,6 +486,7 @@ func newTestUpdater(t *testing.T, scoreOverride map[int64][2]int64) (*Updater, *
 		Logger: zap.NewNop().Sugar(),
 		Writer: cw,
 		ESPN:   client,
+		Sport:  espn.CollegeFootball,
 	}
 
 	return u, cw
@@ -497,24 +499,24 @@ func seedTeamsAndSeasons(t *testing.T, db *gorm.DB) {
 	t.Helper()
 
 	teamNames := []database.TeamName{
-		{TeamID: 1, Name: "Alpha", DisplayName: "Alpha Crimson Tide", Abbreviation: "ALP", Location: "Alpha", Slug: "alpha", IsActive: true},
-		{TeamID: 2, Name: "Beta", DisplayName: "Beta Tigers", Abbreviation: "BET", Location: "Beta", Slug: "beta", IsActive: true},
-		{TeamID: 3, Name: "Gamma", DisplayName: "Gamma Wildcats", Abbreviation: "GAM", Location: "Gamma", Slug: "gamma", IsActive: true},
-		{TeamID: 4, Name: "Delta", DisplayName: "Delta Bulldogs", Abbreviation: "DEL", Location: "Delta", Slug: "delta", IsActive: true},
-		{TeamID: 5, Name: "Epsilon", DisplayName: "Epsilon Eagles", Abbreviation: "EPS", Location: "Epsilon", Slug: "epsilon", IsActive: true},
-		{TeamID: 6, Name: "Zeta", DisplayName: "Zeta Falcons", Abbreviation: "ZET", Location: "Zeta", Slug: "zeta", IsActive: true},
+		{TeamID: 1, Name: "Alpha", DisplayName: "Alpha Crimson Tide", Abbreviation: "ALP", Location: "Alpha", Slug: "alpha", IsActive: true, Sport: "cfb"},
+		{TeamID: 2, Name: "Beta", DisplayName: "Beta Tigers", Abbreviation: "BET", Location: "Beta", Slug: "beta", IsActive: true, Sport: "cfb"},
+		{TeamID: 3, Name: "Gamma", DisplayName: "Gamma Wildcats", Abbreviation: "GAM", Location: "Gamma", Slug: "gamma", IsActive: true, Sport: "cfb"},
+		{TeamID: 4, Name: "Delta", DisplayName: "Delta Bulldogs", Abbreviation: "DEL", Location: "Delta", Slug: "delta", IsActive: true, Sport: "cfb"},
+		{TeamID: 5, Name: "Epsilon", DisplayName: "Epsilon Eagles", Abbreviation: "EPS", Location: "Epsilon", Slug: "epsilon", IsActive: true, Sport: "cfb"},
+		{TeamID: 6, Name: "Zeta", DisplayName: "Zeta Falcons", Abbreviation: "ZET", Location: "Zeta", Slug: "zeta", IsActive: true, Sport: "cfb"},
 	}
 	if err := db.Create(&teamNames).Error; err != nil {
 		t.Fatalf("seed team_names: %v", err)
 	}
 
 	teamSeasons := []database.TeamSeason{
-		{TeamID: 1, Year: 2023, FBS: 1, Conf: "SEC"},
-		{TeamID: 2, Year: 2023, FBS: 1, Conf: "SEC"},
-		{TeamID: 3, Year: 2023, FBS: 1, Conf: "Big Ten"},
-		{TeamID: 4, Year: 2023, FBS: 1, Conf: "Big Ten"},
-		{TeamID: 5, Year: 2023, FBS: 0, Conf: "MVFC"},
-		{TeamID: 6, Year: 2023, FBS: 0, Conf: "MVFC"},
+		{TeamID: 1, Year: 2023, FBS: 1, Conf: "SEC", Sport: "cfb"},
+		{TeamID: 2, Year: 2023, FBS: 1, Conf: "SEC", Sport: "cfb"},
+		{TeamID: 3, Year: 2023, FBS: 1, Conf: "Big Ten", Sport: "cfb"},
+		{TeamID: 4, Year: 2023, FBS: 1, Conf: "Big Ten", Sport: "cfb"},
+		{TeamID: 5, Year: 2023, FBS: 0, Conf: "MVFC", Sport: "cfb"},
+		{TeamID: 6, Year: 2023, FBS: 0, Conf: "MVFC", Sport: "cfb"},
 	}
 	if err := db.Create(&teamSeasons).Error; err != nil {
 		t.Fatalf("seed team_seasons: %v", err)
@@ -531,36 +533,38 @@ func seedGames(t *testing.T, db *gorm.DB) {
 		{
 			GameID: fixtureGameID1, Season: 2023, Week: 1,
 			HomeID: 1, AwayID: 2, HomeScore: 28, AwayScore: 14,
-			ConfGame: true,
+			ConfGame: true, Sport: "cfb",
 			StartTime: time.Date(2023, 9, 2, 23, 0, 0, 0, time.UTC),
 		},
 		{
 			GameID: fixtureGameID2, Season: 2023, Week: 1,
 			HomeID: 3, AwayID: 4, HomeScore: 21, AwayScore: 10,
-			ConfGame: true,
+			ConfGame: true, Sport: "cfb",
 			StartTime: time.Date(2023, 9, 2, 23, 0, 0, 0, time.UTC),
 		},
 		{
 			GameID: fixtureGameID4, Season: 2023, Week: 2,
 			HomeID: 1, AwayID: 3, HomeScore: 35, AwayScore: 17,
+			Sport: "cfb",
 			StartTime: time.Date(2023, 9, 9, 23, 0, 0, 0, time.UTC),
 		},
 		{
 			GameID: fixtureGameID5, Season: 2023, Week: 2,
 			HomeID: 2, AwayID: 4, HomeScore: 24, AwayScore: 21,
+			Sport: "cfb",
 			StartTime: time.Date(2023, 9, 9, 23, 0, 0, 0, time.UTC),
 		},
 		// FCS games
 		{
 			GameID: 501001, Season: 2023, Week: 1,
 			HomeID: 5, AwayID: 6, HomeScore: 17, AwayScore: 10,
-			ConfGame: true,
+			ConfGame: true, Sport: "cfb",
 			StartTime: time.Date(2023, 9, 2, 20, 0, 0, 0, time.UTC),
 		},
 		{
 			GameID: 501002, Season: 2023, Week: 2,
 			HomeID: 6, AwayID: 5, HomeScore: 14, AwayScore: 21,
-			ConfGame: true,
+			ConfGame: true, Sport: "cfb",
 			StartTime: time.Date(2023, 9, 9, 20, 0, 0, 0, time.UTC),
 		},
 	}

--- a/internal/updater/update_games.go
+++ b/internal/updater/update_games.go
@@ -17,7 +17,7 @@ func (u *Updater) checkGames(games []espn.Game) ([]espn.Game, error) {
 		gameIDs = append(gameIDs, game.ID)
 	}
 	var existing []database.Game
-	if err := u.DB.Where("game_id in ?", gameIDs).Find(&existing).Error; err != nil {
+	if err := u.DB.Where("game_id in ? and sport = ?", gameIDs, u.sportDB()).Find(&existing).Error; err != nil {
 		return nil, err
 	}
 

--- a/internal/updater/update_json.go
+++ b/internal/updater/update_json.go
@@ -110,7 +110,7 @@ type resultJSON struct {
 func toJSON(rank *database.TeamWeekResult, teamMap map[int64]teamJSON) *resultJSON {
 	record := fmt.Sprintf("%d-%d", rank.Wins, rank.Losses)
 	if rank.Ties > 0 {
-		record = fmt.Sprintf("%d-%d-%d", rank.Week, rank.Losses, rank.Ties)
+		record = fmt.Sprintf("%d-%d-%d", rank.Wins, rank.Losses, rank.Ties)
 	}
 	return &resultJSON{
 		Team:      teamMap[rank.TeamID],
@@ -289,6 +289,10 @@ func (u *Updater) UpdateRecentJSON() error {
 		return err
 	}
 
+	if err := u.UpdateTeamsJSON(teamMap); err != nil {
+		return err
+	}
+
 	if err := u.UpdateGameCountJSON(teamMap); err != nil {
 		return err
 	}
@@ -331,7 +335,7 @@ func (u *Updater) UpdateRecentJSON() error {
 		if yearInfo.Postseason > 0 {
 			if err := u.DB.Where(
 				"sport = ? and year = ? and fbs = ? and postseason = 1",
-				sport, yearInfo.Year, division == fbs,
+				sport, yearInfo.Year, division == fbs || division == d1,
 			).
 				Order("final_rank").
 				Find(&weekRankings).Error; err != nil {
@@ -340,7 +344,7 @@ func (u *Updater) UpdateRecentJSON() error {
 		} else {
 			if err := u.DB.Where(
 				"sport = ? and year = ? and fbs = ? and week = ? and postseason = 0",
-				sport, yearInfo.Year, division == fbs, yearInfo.Week,
+				sport, yearInfo.Year, division == fbs || division == d1, yearInfo.Week,
 			).
 				Order("final_rank").
 				Find(&weekRankings).Error; err != nil {

--- a/internal/updater/update_json.go
+++ b/internal/updater/update_json.go
@@ -7,20 +7,32 @@ import (
 	"strconv"
 
 	"github.com/robby-barton/stats-go/internal/database"
+	"github.com/robby-barton/stats-go/internal/espn"
 )
 
 const (
 	fbs = "fbs"
 	fcs = "fcs"
+	d1  = "d1"
 )
 
+// divisions returns the division names used for ranking output for this sport.
+func (u *Updater) divisions() []string {
+	if u.Sport == espn.CollegeBasketball {
+		return []string{d1}
+	}
+	return []string{fbs, fcs}
+}
+
 func (u *Updater) UpdateAvailRanksJSON() error {
+	sport := u.sportDB()
 	years := []struct {
 		Year       int64 `json:"-"`
 		Weeks      int64 `json:"weeks"`
 		Postseason int64 `json:"postseason"`
 	}{}
 	if err := u.DB.Model(&database.TeamWeekResult{}).
+		Where("sport = ?", sport).
 		Select("year, max(case when postseason = 0 then week else 0 end) as weeks, max(postseason) as postseason").
 		Group("year").Order("year").Scan(&years).Error; err != nil {
 		return err
@@ -31,7 +43,7 @@ func (u *Updater) UpdateAvailRanksJSON() error {
 		availRanks[year.Year] = year
 	}
 
-	return u.Writer.WriteData(context.Background(), "availRanks.json", availRanks)
+	return u.Writer.WriteData(context.Background(), sport+"/availRanks.json", availRanks)
 }
 
 type teamJSON struct {
@@ -44,6 +56,7 @@ type teamJSON struct {
 func (u *Updater) getTeamInfo() (map[int64]teamJSON, error) {
 	teams := []teamJSON{}
 	if err := u.DB.Model(&database.TeamName{}).
+		Where("sport = ?", u.sportDB()).
 		Select("team_id as id, name, logo, logo_dark").
 		Scan(&teams).Error; err != nil {
 		return nil, err
@@ -58,6 +71,7 @@ func (u *Updater) getTeamInfo() (map[int64]teamJSON, error) {
 }
 
 func (u *Updater) UpdateTeamsJSON(teamMap map[int64]teamJSON) error {
+	sport := u.sportDB()
 	teamList := []teamJSON{}
 	if teamMap != nil {
 		for _, team := range teamMap {
@@ -65,13 +79,14 @@ func (u *Updater) UpdateTeamsJSON(teamMap map[int64]teamJSON) error {
 		}
 	} else {
 		if err := u.DB.Model(&database.TeamName{}).
+			Where("sport = ?", sport).
 			Select("team_id as id, name, logo, logo_dark").
 			Scan(&teamList).Error; err != nil {
 			return err
 		}
 	}
 
-	return u.Writer.WriteData(context.Background(), "teams.json", teamList)
+	return u.Writer.WriteData(context.Background(), sport+"/teams.json", teamList)
 }
 
 type rankingsJSON struct {
@@ -109,16 +124,17 @@ func toJSON(rank *database.TeamWeekResult, teamMap map[int64]teamJSON) *resultJS
 }
 
 func (u *Updater) UpdateRankJSON(week *rankingsJSON) error {
+	sport := u.sportDB()
 	weekName := "final"
 	if !week.Postseason {
 		weekName = strconv.FormatInt(week.Week, 10)
 	}
-	fileName := fmt.Sprintf("ranking/%d/%s/%s.json", week.Year, week.Division, weekName)
+	fileName := fmt.Sprintf("%s/ranking/%d/%s/%s.json", sport, week.Year, week.Division, weekName)
 	return u.Writer.WriteData(context.Background(), fileName, week.Results)
 }
 
 func (u *Updater) UpdateIndexJSON(week *rankingsJSON) error {
-	return u.Writer.WriteData(context.Background(), "latest.json", week.Results)
+	return u.Writer.WriteData(context.Background(), u.sportDB()+"/latest.json", week.Results)
 }
 
 type teamRankJSON struct {
@@ -134,9 +150,10 @@ type teamRankList struct {
 }
 
 func (u *Updater) UpdateTeamRankJSON(team teamJSON) error {
+	sport := u.sportDB()
 	teamRankings := []database.TeamWeekResult{}
 	if err := u.DB.Model(&database.TeamWeekResult{}).Where(
-		"team_id = ?", team.ID,
+		"sport = ? and team_id = ?", sport, team.ID,
 	).Order("year, postseason, week").Find(&teamRankings).Error; err != nil {
 		return err
 	}
@@ -164,7 +181,7 @@ func (u *Updater) UpdateTeamRankJSON(team teamJSON) error {
 		Years:    years,
 	}
 
-	fileName := fmt.Sprintf("team/%d.json", team.ID)
+	fileName := fmt.Sprintf("%s/team/%d.json", sport, team.ID)
 	return u.Writer.WriteData(context.Background(), fileName, results)
 }
 
@@ -181,6 +198,7 @@ type gameCountJSON struct {
 }
 
 func (u *Updater) UpdateGameCountJSON(teamMap map[int64]teamJSON) error {
+	sport := u.sportDB()
 	// PostgreSQL: extract(dow from start_time) returns 0=Sun..6=Sat
 	// SQLite: strftime('%w', start_time) returns '0'=Sun..'6'=Sat
 	dowExpr := "extract(dow from start_time)"
@@ -195,12 +213,14 @@ func (u *Updater) UpdateGameCountJSON(teamMap map[int64]teamJSON) error {
 			%s as dow,
 			game_id
 		from games
+		where sport = ?
 		union all
 		select
 			away_id as team_id,
 			%s as dow,
 			game_id
 		from games
+		where sport = ?
 	)
 	select
 		team_id,
@@ -231,7 +251,7 @@ func (u *Updater) UpdateGameCountJSON(teamMap map[int64]teamJSON) error {
 		Total  int64
 	}{}
 
-	if err := u.DB.Raw(sql).Scan(&results).Error; err != nil {
+	if err := u.DB.Raw(sql, sport, sport).Scan(&results).Error; err != nil {
 		return err
 	}
 
@@ -254,10 +274,12 @@ func (u *Updater) UpdateGameCountJSON(teamMap map[int64]teamJSON) error {
 		})
 	}
 
-	return u.Writer.WriteData(context.Background(), "gameCount.json", resultsJSON)
+	return u.Writer.WriteData(context.Background(), sport+"/gameCount.json", resultsJSON)
 }
 
 func (u *Updater) UpdateRecentJSON() error {
+	sport := u.sportDB()
+
 	teamMap, err := u.getTeamInfo()
 	if err != nil {
 		return err
@@ -271,31 +293,30 @@ func (u *Updater) UpdateRecentJSON() error {
 		return err
 	}
 
-	sql := `
-	select 
-		max(year) as year,
-		max(week) as week,
-		max(postseason) as postseason 
-	from team_week_results 
-	where 
-		year = (
-			select 
-				max(year) 
-			from team_week_results
-		)
-	`
 	yearInfo := &struct {
 		Year       int64
 		Week       int64
 		Postseason int64
 	}{}
-	if err := u.DB.Raw(sql).Scan(yearInfo).Error; err != nil {
+	if err := u.DB.Raw(`
+	select
+		max(year) as year,
+		max(week) as week,
+		max(postseason) as postseason
+	from team_week_results
+	where
+		sport = ? and
+		year = (
+			select max(year) from team_week_results where sport = ?
+		)
+	`, sport, sport).Scan(yearInfo).Error; err != nil {
 		return err
 	}
 
 	teams := []int64{}
 	if err := u.DB.Model(&database.TeamWeekResult{}).
-		Distinct("team_id").Where("year = ?", yearInfo.Year).Pluck("team_id", &teams).Error; err != nil {
+		Distinct("team_id").Where("sport = ? and year = ?", sport, yearInfo.Year).
+		Pluck("team_id", &teams).Error; err != nil {
 		return err
 	}
 	for _, team := range teams {
@@ -304,12 +325,13 @@ func (u *Updater) UpdateRecentJSON() error {
 		}
 	}
 
-	for _, division := range []string{fbs, fcs} {
+	divisions := u.divisions()
+	for _, division := range divisions {
 		weekRankings := []database.TeamWeekResult{}
 		if yearInfo.Postseason > 0 {
 			if err := u.DB.Where(
-				"year = ? and fbs = ? and postseason = 1",
-				yearInfo.Year, division == fbs,
+				"sport = ? and year = ? and fbs = ? and postseason = 1",
+				sport, yearInfo.Year, division == fbs,
 			).
 				Order("final_rank").
 				Find(&weekRankings).Error; err != nil {
@@ -317,8 +339,8 @@ func (u *Updater) UpdateRecentJSON() error {
 			}
 		} else {
 			if err := u.DB.Where(
-				"year = ? and fbs = ? and week = ? and postseason = 0",
-				yearInfo.Year, division == fbs, yearInfo.Week,
+				"sport = ? and year = ? and fbs = ? and week = ? and postseason = 0",
+				sport, yearInfo.Year, division == fbs, yearInfo.Week,
 			).
 				Order("final_rank").
 				Find(&weekRankings).Error; err != nil {
@@ -342,7 +364,7 @@ func (u *Updater) UpdateRecentJSON() error {
 			return err
 		}
 
-		if division == fbs {
+		if division == fbs || (u.Sport == espn.CollegeBasketball && division == d1) {
 			if err := u.UpdateIndexJSON(json); err != nil {
 				return err
 			}
@@ -353,6 +375,8 @@ func (u *Updater) UpdateRecentJSON() error {
 }
 
 func (u *Updater) UpdateAllJSON() error {
+	sport := u.sportDB()
+
 	teamMap, err := u.getTeamInfo()
 	if err != nil {
 		return err
@@ -372,6 +396,7 @@ func (u *Updater) UpdateAllJSON() error {
 
 	teams := []int64{}
 	if err := u.DB.Model(&database.TeamWeekResult{}).
+		Where("sport = ?", sport).
 		Distinct("team_id").Pluck("team_id", &teams).Error; err != nil {
 		return err
 	}
@@ -387,14 +412,16 @@ func (u *Updater) UpdateAllJSON() error {
 	}
 
 	var latestRanking *rankingsJSON
+	divisions := u.divisions()
+	primaryDivision := divisions[0]
 
-	for _, division := range []string{fbs, fcs} {
+	for _, division := range divisions {
 		for _, year := range yearInfo {
 			for week := int64(1); week <= year.Weeks; week++ {
 				weekRankings := []database.TeamWeekResult{}
 				if err := u.DB.Where(
-					"year = ? and fbs = ? and week = ? and postseason = ?",
-					year.Year, division == fbs, week, 0,
+					"sport = ? and year = ? and fbs = ? and week = ? and postseason = ?",
+					sport, year.Year, division == fbs || division == d1, week, 0,
 				).
 					Order("final_rank").
 					Find(&weekRankings).Error; err != nil {
@@ -422,8 +449,8 @@ func (u *Updater) UpdateAllJSON() error {
 			if year.Postseason > 0 {
 				weekRankings := []database.TeamWeekResult{}
 				if err := u.DB.Where(
-					"year = ? and fbs = ? and postseason = ?",
-					year.Year, division == fbs, 1,
+					"sport = ? and year = ? and fbs = ? and postseason = ?",
+					sport, year.Year, division == fbs || division == d1, 1,
 				).
 					Order("final_rank").
 					Find(&weekRankings).Error; err != nil {
@@ -445,8 +472,8 @@ func (u *Updater) UpdateAllJSON() error {
 			} else {
 				weekRankings := []database.TeamWeekResult{}
 				if err := u.DB.Where(
-					"year = ? and fbs = ? and week = ? and postseason = ?",
-					year.Year, division == fbs, year.Weeks+1, 0,
+					"sport = ? and year = ? and fbs = ? and week = ? and postseason = ?",
+					sport, year.Year, division == fbs || division == d1, year.Weeks+1, 0,
 				).
 					Order("final_rank").
 					Find(&weekRankings).Error; err != nil {
@@ -470,7 +497,7 @@ func (u *Updater) UpdateAllJSON() error {
 				return err
 			}
 
-			if division == fbs {
+			if division == primaryDivision {
 				latestRanking = final
 			}
 		}

--- a/internal/updater/update_json.go
+++ b/internal/updater/update_json.go
@@ -18,7 +18,7 @@ const (
 
 // divisions returns the division names used for ranking output for this sport.
 func (u *Updater) divisions() []string {
-	if u.Sport == espn.CollegeBasketball {
+	if u.ESPN.SportInfo() == espn.CollegeBasketball {
 		return []string{d1}
 	}
 	return []string{fbs, fcs}
@@ -364,7 +364,7 @@ func (u *Updater) UpdateRecentJSON() error {
 			return err
 		}
 
-		if division == fbs || (u.Sport == espn.CollegeBasketball && division == d1) {
+		if division == fbs || (u.ESPN.SportInfo() == espn.CollegeBasketball && division == d1) {
 			if err := u.UpdateIndexJSON(json); err != nil {
 				return err
 			}

--- a/internal/updater/update_team_info.go
+++ b/internal/updater/update_team_info.go
@@ -66,7 +66,12 @@ func (u *Updater) UpdateTeamInfo() (int, error) {
 		return 0, err
 	}
 
-	if err = u.insertTeamsToDB(apiToDB(teamInfo)); err != nil {
+	dbTeams := apiToDB(teamInfo)
+	for i := range dbTeams {
+		dbTeams[i].Sport = u.sportDB()
+	}
+
+	if err = u.insertTeamsToDB(dbTeams); err != nil {
 		return 0, err
 	}
 

--- a/internal/updater/update_team_season.go
+++ b/internal/updater/update_team_season.go
@@ -54,7 +54,7 @@ func (u *Updater) UpdateTeamSeasons(force bool) (int, error) {
 
 	var teamSeasons []database.TeamSeason
 
-	if u.Sport == espn.CollegeBasketball {
+	if u.ESPN.SportInfo() == espn.CollegeBasketball {
 		// Basketball: all D1 teams are top-division (FBS=1). Conference names
 		// come from the conference API but there's no FBS/FCS split.
 		conferences, err := u.ESPN.ConferenceMap()

--- a/internal/updater/update_team_season.go
+++ b/internal/updater/update_team_season.go
@@ -71,9 +71,9 @@ func (u *Updater) UpdateTeamSeasons(force bool) (int, error) {
 		}
 
 		for team, conf := range teamConfs {
-			confName := d1Confs[conf]
-			if confName == "" {
-				confName = "D1"
+			confName, ok := d1Confs[conf]
+			if !ok {
+				continue // skip non-D1 teams (e.g. D2/D3/NAIA opponents)
 			}
 			teamSeasons = append(teamSeasons, database.TeamSeason{
 				TeamID: team,

--- a/internal/updater/update_team_week_results.go
+++ b/internal/updater/update_team_week_results.go
@@ -72,7 +72,7 @@ func (u *Updater) rankingForWeek(year int64, week int64) ([]database.TeamWeekRes
 	sport := u.sportDB()
 	var teamWeekResults []database.TeamWeekResult
 
-	if u.Sport == espn.CollegeBasketball {
+	if u.ESPN.SportInfo() == espn.CollegeBasketball {
 		// Basketball: single D1 ranking, no FBS/FCS split
 		ranker := ranking.Ranker{
 			DB:    u.DB,

--- a/internal/updater/update_team_week_results.go
+++ b/internal/updater/update_team_week_results.go
@@ -5,6 +5,7 @@ import (
 	"gorm.io/gorm/clause"
 
 	"github.com/robby-barton/stats-go/internal/database"
+	"github.com/robby-barton/stats-go/internal/espn"
 	"github.com/robby-barton/stats-go/internal/ranking"
 )
 
@@ -18,7 +19,7 @@ func (u *Updater) getYearInfo() ([]yearInfo, error) {
 	var yearInfo []yearInfo
 	if err := u.DB.Model(database.Game{}).
 		Select(`season as year, max(week) as weeks, max(postseason) as postseason`).
-		Where("season >= ?", 1936). // first official year of AP poll
+		Where("sport = ? and season >= ?", u.sportDB(), 1936). // first official year of AP poll
 		Group("season").
 		Order("season").Find(&yearInfo).Error; err != nil {
 		return nil, err
@@ -41,7 +42,7 @@ func (u *Updater) insertRankingsToDB(rankings []database.TeamWeekResult) error {
 	})
 }
 
-func teamListToTeamWeekResult(teamList ranking.TeamList, fbs bool) []database.TeamWeekResult {
+func teamListToTeamWeekResult(teamList ranking.TeamList, fbs bool, sport string) []database.TeamWeekResult {
 	var retTWR []database.TeamWeekResult
 
 	for id, result := range teamList {
@@ -52,6 +53,7 @@ func teamListToTeamWeekResult(teamList ranking.TeamList, fbs bool) []database.Te
 			Year:       result.Year,
 			Week:       result.Week,
 			Postseason: result.Postseason,
+			Sport:      sport,
 			FinalRank:  result.FinalRank,
 			FinalRaw:   result.FinalRaw,
 			Wins:       result.Record.Wins,
@@ -67,30 +69,48 @@ func teamListToTeamWeekResult(teamList ranking.TeamList, fbs bool) []database.Te
 }
 
 func (u *Updater) rankingForWeek(year int64, week int64) ([]database.TeamWeekResult, error) {
+	sport := u.sportDB()
 	var teamWeekResults []database.TeamWeekResult
 
-	fbsRanker := ranking.Ranker{
-		DB:   u.DB,
-		Year: year,
-		Week: week,
-	}
-	fbsRanking, err := fbsRanker.CalculateRanking()
-	if err != nil {
-		return nil, err
-	}
-	teamWeekResults = append(teamWeekResults, teamListToTeamWeekResult(fbsRanking, true)...)
+	if u.Sport == espn.CollegeBasketball {
+		// Basketball: single D1 ranking, no FBS/FCS split
+		ranker := ranking.Ranker{
+			DB:    u.DB,
+			Year:  year,
+			Week:  week,
+			Sport: sport,
+		}
+		teamList, err := ranker.CalculateRanking()
+		if err != nil {
+			return nil, err
+		}
+		teamWeekResults = append(teamWeekResults, teamListToTeamWeekResult(teamList, true, sport)...)
+	} else {
+		fbsRanker := ranking.Ranker{
+			DB:    u.DB,
+			Year:  year,
+			Week:  week,
+			Sport: sport,
+		}
+		fbsRanking, err := fbsRanker.CalculateRanking()
+		if err != nil {
+			return nil, err
+		}
+		teamWeekResults = append(teamWeekResults, teamListToTeamWeekResult(fbsRanking, true, sport)...)
 
-	fcsRanker := ranking.Ranker{
-		DB:   u.DB,
-		Year: year,
-		Week: week,
-		Fcs:  true,
+		fcsRanker := ranking.Ranker{
+			DB:    u.DB,
+			Year:  year,
+			Week:  week,
+			Fcs:   true,
+			Sport: sport,
+		}
+		fcsRanking, err := fcsRanker.CalculateRanking()
+		if err != nil {
+			return nil, err
+		}
+		teamWeekResults = append(teamWeekResults, teamListToTeamWeekResult(fcsRanking, false, sport)...)
 	}
-	fcsRanking, err := fcsRanker.CalculateRanking()
-	if err != nil {
-		return nil, err
-	}
-	teamWeekResults = append(teamWeekResults, teamListToTeamWeekResult(fcsRanking, false)...)
 
 	return teamWeekResults, nil
 }

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -12,11 +12,10 @@ type Updater struct {
 	DB     *gorm.DB
 	Logger *zap.SugaredLogger
 	Writer writer.Writer
-	ESPN   *espn.Client
-	Sport  espn.Sport // CollegeFootball or CollegeBasketball
+	ESPN   espn.SportClient
 }
 
 // sportDB returns the short database identifier for the updater's sport.
 func (u *Updater) sportDB() string {
-	return u.Sport.SportDB()
+	return u.ESPN.SportInfo().SportDB()
 }

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -13,4 +13,10 @@ type Updater struct {
 	Logger *zap.SugaredLogger
 	Writer writer.Writer
 	ESPN   *espn.Client
+	Sport  espn.Sport // CollegeFootball or CollegeBasketball
+}
+
+// sportDB returns the short database identifier for the updater's sport.
+func (u *Updater) sportDB() string {
+	return u.Sport.SportDB()
 }

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -258,9 +258,9 @@ func TestUpdateRecentJSON(t *testing.T) {
 
 	// Verify expected files were written
 	expectedFiles := []string{
-		"availRanks.json",
-		"gameCount.json",
-		"latest.json",
+		"cfb/availRanks.json",
+		"cfb/gameCount.json",
+		"cfb/latest.json",
 	}
 	for _, f := range expectedFiles {
 		if !cw.hasFile(f) {


### PR DESCRIPTION
## Summary

- Introduce `espn.Sport` type (`CollegeFootball`, `CollegeBasketball`) to parameterize ESPN client URLs, group IDs, and season types per sport
- Add `sport` column to shared DB tables (`games`, `team_names`, `team_seasons`, `team_week_results`) with migration script
- Update ranker and updater CLIs with `football`/`basketball` subcommands via cobra
- Adapt ranking algorithm for basketball (no FCS subdivision, different week/season handling)
- Add basketball-specific integration tests for ranking and updater packages
- Update ARCHITECTURE.md, CLAUDE.md, README.md, and design-decisions.md

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run` reports 0 issues
- [ ] Manual smoke test: `ranker basketball -y 2025 -w 10`
- [ ] Manual smoke test: `updater basketball`
- [ ] Verify migration script applies cleanly to existing DB