### PR TITLE
Rename sport identifier: ncaambb → ncaam

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,10 +51,10 @@ The system supports college football and basketball through a `Sport` type in th
 ESPN package (`espn.CollegeFootball`, `espn.CollegeBasketball`). Each sport has:
 
 - **ESPN client configuration:** Different API URLs, group IDs, season types
-- **Database separation:** Shared tables use a `sport` column (`"ncaaf"` or `"ncaambb"`)
+- **Database separation:** Shared tables use a `sport` column (`"ncaaf"` or `"ncaam"`)
 - **Ranking constants:** Sport-dependent `requiredGames`, `yearsBack`, and MOV caps
 - **Division structure:** Football has FBS/FCS; basketball has D1 only
-- **JSON output paths:** Sport-prefixed (`ncaaf/ranking/...`, `ncaambb/ranking/...`)
+- **JSON output paths:** Sport-prefixed (`ncaaf/ranking/...`, `ncaam/ranking/...`)
 
 The `Updater` and `Ranker` structs each carry a sport identifier. The CLI
 exposes sport subcommands (`football`, `basketball`). The `schedule` command runs
@@ -122,7 +122,7 @@ type Ranker struct {
     Year  int64
     Week  int64
     Fcs   bool
-    Sport string  // "ncaaf" or "ncaambb"
+    Sport string  // "ncaaf" or "ncaam"
 }
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the full dependency graph and design
 rationale.
 
 Key patterns:
-- **Multi-sport support** — Football (`ncaaf`) and basketball (`ncaambb`) via `espn.Sport` type
+- **Multi-sport support** — Football (`ncaaf`) and basketball (`ncaam`) via `espn.Sport` type
 - **Three independent CLI entry points** in `cmd/` — each wires its own deps
 - **Sport subcommands** — CLIs use `football`/`basketball` subcommands; `schedule` runs both
 - **Writer interface** (`internal/writer`) — pluggable output (DO Spaces vs local files)

--- a/cmd/ranker/main.go
+++ b/cmd/ranker/main.go
@@ -30,9 +30,9 @@ func main() {
 	rootCmd.SilenceUsage = true
 
 	ncaafCmd := sportRankCmd(db, "ncaaf", true)
-	ncaambbCmd := sportRankCmd(db, "ncaambb", false)
+	ncaamCmd := sportRankCmd(db, "ncaam", false)
 
-	rootCmd.AddCommand(ncaafCmd, ncaambbCmd)
+	rootCmd.AddCommand(ncaafCmd, ncaamCmd)
 
 	rootCmd.Execute() //nolint:errcheck // cobra prints errors; exit code unused
 }
@@ -44,8 +44,8 @@ func sportRankCmd(db *gorm.DB, sport string, hasFCS bool) *cobra.Command {
 
 	use := "ncaaf"
 	short := "Calculate NCAA football rankings"
-	if sport == "ncaambb" {
-		use = "ncaambb"
+	if sport == "ncaam" {
+		use = "ncaam"
 		short = "Calculate NCAA men's basketball rankings"
 	}
 

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -46,9 +46,9 @@ func main() {
 
 	scheduleCmd := scheduleCommand(log, cfg, db, doWriter)
 	ncaafCmd := sportCommand(log, db, doWriter, espn.CollegeFootball)
-	ncaambbCmd := sportCommand(log, db, doWriter, espn.CollegeBasketball)
+	ncaamCmd := sportCommand(log, db, doWriter, espn.CollegeBasketball)
 
-	rootCmd.AddCommand(scheduleCmd, ncaafCmd, ncaambbCmd)
+	rootCmd.AddCommand(scheduleCmd, ncaafCmd, ncaamCmd)
 
 	rootCmd.Execute() //nolint:errcheck // cobra prints errors; exit code unused
 }
@@ -213,7 +213,7 @@ func scheduleCommand(
 				},
 				{
 					schedule: sportSchedule{
-						Name:          "ncaambb",
+						Name:          "ncaam",
 						GamesCron:     "*/5 * * 1-4,11-12 *",
 						TeamInfoCron:  "0 5 * 1-4,11-12 0",
 						NewSeasonCron: "0 6 1 11 *",
@@ -258,7 +258,7 @@ func sportCommand(
 	use := "ncaaf"
 	short := "NCAA football one-shot commands"
 	if sport == espn.CollegeBasketball {
-		use = "ncaambb"
+		use = "ncaam"
 		short = "NCAA men's basketball one-shot commands"
 	}
 

--- a/db/migration_rename_ncaambb.sql
+++ b/db/migration_rename_ncaambb.sql
@@ -1,0 +1,20 @@
+-- Rename sport identifier: ncaambb → ncaam
+-- Aligns with standard abbreviation and leaves room for ncaaw in the future.
+
+BEGIN;
+
+-- Drop FK that references team_names(team_id, sport) so both tables
+-- can be updated independently within the transaction.
+ALTER TABLE team_week_results DROP CONSTRAINT team_week_result_team_id_fkey;
+
+UPDATE games SET sport = 'ncaam' WHERE sport = 'ncaambb';
+UPDATE team_names SET sport = 'ncaam' WHERE sport = 'ncaambb';
+UPDATE team_seasons SET sport = 'ncaam' WHERE sport = 'ncaambb';
+UPDATE team_week_results SET sport = 'ncaam' WHERE sport = 'ncaambb';
+
+-- Re-add FK now that both tables use the new sport values
+ALTER TABLE team_week_results
+    ADD CONSTRAINT team_week_result_team_id_fkey
+    FOREIGN KEY (team_id, sport) REFERENCES team_names(team_id, sport) ON DELETE CASCADE;
+
+COMMIT;

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -47,7 +47,7 @@ See `internal/ranking/rating.go`.
 
 Football and basketball data share the same tables (`games`, `team_names`,
 `team_seasons`, `team_week_results`) differentiated by a `sport` column
-(`"ncaaf"` or `"ncaambb"`). This avoids duplicating schema definitions and keeps
+(`"ncaaf"` or `"ncaam"`). This avoids duplicating schema definitions and keeps
 queries simple — just add `WHERE sport = ?`. The alternative (separate tables
 per sport) was rejected because the data models are identical and separate
 tables would mean duplicating every query and migration.
@@ -106,7 +106,7 @@ interface. This allows:
 - Local dev: plain JSON files written to disk
 - Testing: mock writers
 
-JSON output paths are sport-prefixed (`ncaaf/ranking/...`, `ncaambb/ranking/...`) to
+JSON output paths are sport-prefixed (`ncaaf/ranking/...`, `ncaam/ranking/...`) to
 keep football and basketball data separate in the output bucket.
 
 ## Scheduled Updates During Season

--- a/docs/migration-rules.md
+++ b/docs/migration-rules.md
@@ -57,7 +57,7 @@ production.
 ## Schema Design Constraints
 
 - Shared tables (`games`, `team_names`, `team_seasons`, `team_week_results`)
-  carry a `sport` column (`"ncaaf"` or `"ncaambb"`). New columns on these tables
+  carry a `sport` column (`"ncaaf"` or `"ncaam"`). New columns on these tables
   must be sport-agnostic or include sport-specific defaults.
 - `team_names` uses `(team_id, sport)` as its composite primary key. ESPN
   reuses team IDs across sports. Do not collapse this back to a single-column

--- a/internal/espn/espn.go
+++ b/internal/espn/espn.go
@@ -17,7 +17,7 @@ const (
 // Short database identifiers for each sport.
 const (
 	SportDBFootball   = "ncaaf"
-	SportDBBasketball = "ncaambb"
+	SportDBBasketball = "ncaam"
 )
 
 // SportDB returns the short database identifier for the sport.

--- a/internal/espn/espn_test.go
+++ b/internal/espn/espn_test.go
@@ -378,8 +378,8 @@ func TestSportDB(t *testing.T) {
 	if got := CollegeFootball.SportDB(); got != "ncaaf" {
 		t.Errorf("CollegeFootball.SportDB() = %q, want %q", got, "ncaaf")
 	}
-	if got := CollegeBasketball.SportDB(); got != "ncaambb" {
-		t.Errorf("CollegeBasketball.SportDB() = %q, want %q", got, "ncaambb")
+	if got := CollegeBasketball.SportDB(); got != "ncaam" {
+		t.Errorf("CollegeBasketball.SportDB() = %q, want %q", got, "ncaam")
 	}
 }
 

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -176,8 +176,8 @@ func TestGetSingleGame_Basketball(t *testing.T) {
 		t.Fatalf("GetSingleGame: %v", err)
 	}
 
-	if parsed.GameInfo.Sport != "ncaambb" {
-		t.Errorf("Sport = %q, want %q", parsed.GameInfo.Sport, "ncaambb")
+	if parsed.GameInfo.Sport != "ncaam" {
+		t.Errorf("Sport = %q, want %q", parsed.GameInfo.Sport, "ncaam")
 	}
 	if parsed.GameInfo.GameID != 2001 {
 		t.Errorf("GameID = %d, want 2001", parsed.GameInfo.GameID)

--- a/internal/ranking/ranking.go
+++ b/internal/ranking/ranking.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	sportFootball   = "ncaaf"
-	sportBasketball = "ncaambb"
+	sportBasketball = "ncaam"
 )
 
 type Ranker struct {

--- a/internal/ranking/ranking_basketball_test.go
+++ b/internal/ranking/ranking_basketball_test.go
@@ -17,22 +17,22 @@ func seedBasketballData(t *testing.T, db *gorm.DB) {
 	t.Helper()
 
 	teamNames := []database.TeamName{
-		{TeamID: 101, Name: "Hoops A", Sport: "ncaambb"},
-		{TeamID: 102, Name: "Hoops B", Sport: "ncaambb"},
-		{TeamID: 103, Name: "Hoops C", Sport: "ncaambb"},
-		{TeamID: 104, Name: "Hoops D", Sport: "ncaambb"},
-		{TeamID: 105, Name: "Hoops E", Sport: "ncaambb"},
+		{TeamID: 101, Name: "Hoops A", Sport: "ncaam"},
+		{TeamID: 102, Name: "Hoops B", Sport: "ncaam"},
+		{TeamID: 103, Name: "Hoops C", Sport: "ncaam"},
+		{TeamID: 104, Name: "Hoops D", Sport: "ncaam"},
+		{TeamID: 105, Name: "Hoops E", Sport: "ncaam"},
 	}
 	if err := db.Create(&teamNames).Error; err != nil {
 		t.Fatalf("seed basketball team_names: %v", err)
 	}
 
 	teamSeasons := []database.TeamSeason{
-		{TeamID: 101, Year: 2024, FBS: 1, Conf: "Big East", Sport: "ncaambb"},
-		{TeamID: 102, Year: 2024, FBS: 1, Conf: "Big East", Sport: "ncaambb"},
-		{TeamID: 103, Year: 2024, FBS: 1, Conf: "ACC", Sport: "ncaambb"},
-		{TeamID: 104, Year: 2024, FBS: 1, Conf: "ACC", Sport: "ncaambb"},
-		{TeamID: 105, Year: 2024, FBS: 1, Conf: "Big 12", Sport: "ncaambb"},
+		{TeamID: 101, Year: 2024, FBS: 1, Conf: "Big East", Sport: "ncaam"},
+		{TeamID: 102, Year: 2024, FBS: 1, Conf: "Big East", Sport: "ncaam"},
+		{TeamID: 103, Year: 2024, FBS: 1, Conf: "ACC", Sport: "ncaam"},
+		{TeamID: 104, Year: 2024, FBS: 1, Conf: "ACC", Sport: "ncaam"},
+		{TeamID: 105, Year: 2024, FBS: 1, Conf: "Big 12", Sport: "ncaam"},
 	}
 	if err := db.Create(&teamSeasons).Error; err != nil {
 		t.Fatalf("seed basketball team_seasons: %v", err)
@@ -44,18 +44,18 @@ func seedBasketballData(t *testing.T, db *gorm.DB) {
 	games := []database.Game{
 		// Week 1
 		{GameID: 3001, Season: 2024, Week: 1, HomeID: 101, AwayID: 102,
-			HomeScore: 78, AwayScore: 65, ConfGame: true, Sport: "ncaambb", StartTime: base},
+			HomeScore: 78, AwayScore: 65, ConfGame: true, Sport: "ncaam", StartTime: base},
 		{GameID: 3002, Season: 2024, Week: 1, HomeID: 103, AwayID: 104,
-			HomeScore: 70, AwayScore: 68, ConfGame: true, Sport: "ncaambb", StartTime: base.Add(time.Hour)},
+			HomeScore: 70, AwayScore: 68, ConfGame: true, Sport: "ncaam", StartTime: base.Add(time.Hour)},
 		{GameID: 3003, Season: 2024, Week: 1, HomeID: 105, AwayID: 101,
-			HomeScore: 60, AwayScore: 72, Sport: "ncaambb", StartTime: base.Add(2 * time.Hour)},
+			HomeScore: 60, AwayScore: 72, Sport: "ncaam", StartTime: base.Add(2 * time.Hour)},
 		// Week 2
 		{GameID: 3004, Season: 2024, Week: 2, HomeID: 101, AwayID: 103,
-			HomeScore: 80, AwayScore: 75, Sport: "ncaambb", StartTime: base.Add(week)},
+			HomeScore: 80, AwayScore: 75, Sport: "ncaam", StartTime: base.Add(week)},
 		{GameID: 3005, Season: 2024, Week: 2, HomeID: 102, AwayID: 104,
-			HomeScore: 66, AwayScore: 64, Sport: "ncaambb", StartTime: base.Add(week + time.Hour)},
+			HomeScore: 66, AwayScore: 64, Sport: "ncaam", StartTime: base.Add(week + time.Hour)},
 		{GameID: 3006, Season: 2024, Week: 2, HomeID: 105, AwayID: 103,
-			HomeScore: 55, AwayScore: 55, Sport: "ncaambb", StartTime: base.Add(week + 2*time.Hour)},
+			HomeScore: 55, AwayScore: 55, Sport: "ncaam", StartTime: base.Add(week + 2*time.Hour)},
 	}
 	if err := db.Create(&games).Error; err != nil {
 		t.Fatalf("seed basketball games: %v", err)
@@ -79,7 +79,7 @@ func TestSetGlobals_Basketball(t *testing.T) {
 	// Also seed football data to ensure it's ignored
 	seedTestData(t, db)
 
-	r := &Ranker{DB: db, Sport: "ncaambb"}
+	r := &Ranker{DB: db, Sport: "ncaam"}
 	if err := r.setGlobals(); err != nil {
 		t.Fatalf("setGlobals: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestCreateTeamList_Basketball(t *testing.T) {
 	db := setupTestDB(t)
 	seedBasketballData(t, db)
 
-	r := &Ranker{DB: db, Year: 2024, Week: 3, Sport: "ncaambb"}
+	r := &Ranker{DB: db, Year: 2024, Week: 3, Sport: "ncaam"}
 
 	// All basketball teams have FBS=1
 	teamList, err := r.createTeamList(1)
@@ -125,7 +125,7 @@ func TestRecord_Basketball(t *testing.T) {
 	r := &Ranker{
 		DB:        db,
 		Year:      2024,
-		Sport:     "ncaambb",
+		Sport:     "ncaam",
 		startTime: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC), // after all games
 	}
 
@@ -158,7 +158,7 @@ func TestSRS_Basketball(t *testing.T) {
 	r := &Ranker{
 		DB:        db,
 		Year:      2024,
-		Sport:     "ncaambb",
+		Sport:     "ncaam",
 		startTime: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
 	}
 
@@ -199,7 +199,7 @@ func TestCalculateRanking_Basketball(t *testing.T) {
 	r := &Ranker{
 		DB:    db,
 		Year:  2024,
-		Sport: "ncaambb",
+		Sport: "ncaam",
 	}
 
 	teamList, err := r.CalculateRanking()
@@ -207,7 +207,7 @@ func TestCalculateRanking_Basketball(t *testing.T) {
 		t.Fatalf("CalculateRanking: %v", err)
 	}
 
-	// All 5 basketball teams should be included (all FBS=1 for ncaambb)
+	// All 5 basketball teams should be included (all FBS=1 for ncaam)
 	if len(teamList) != 5 {
 		t.Fatalf("len(teamList) = %d, want 5", len(teamList))
 	}

--- a/internal/updater/updater_basketball_test.go
+++ b/internal/updater/updater_basketball_test.go
@@ -282,20 +282,20 @@ func seedBasketballTeamsAndSeasons(t *testing.T, db *gorm.DB) {
 	t.Helper()
 
 	teamNames := []database.TeamName{
-		{TeamID: 11, Name: "BBall Alpha", DisplayName: "BBall Alpha Bulldogs", Abbreviation: "BBA", Location: "BBall Alpha", Slug: "bball-alpha", IsActive: true, Sport: "ncaambb"},
-		{TeamID: 12, Name: "BBall Beta", DisplayName: "BBall Beta Wildcats", Abbreviation: "BBB", Location: "BBall Beta", Slug: "bball-beta", IsActive: true, Sport: "ncaambb"},
-		{TeamID: 13, Name: "BBall Gamma", DisplayName: "BBall Gamma Eagles", Abbreviation: "BBG", Location: "BBall Gamma", Slug: "bball-gamma", IsActive: true, Sport: "ncaambb"},
-		{TeamID: 14, Name: "BBall Delta", DisplayName: "BBall Delta Hawks", Abbreviation: "BBD", Location: "BBall Delta", Slug: "bball-delta", IsActive: true, Sport: "ncaambb"},
+		{TeamID: 11, Name: "BBall Alpha", DisplayName: "BBall Alpha Bulldogs", Abbreviation: "BBA", Location: "BBall Alpha", Slug: "bball-alpha", IsActive: true, Sport: "ncaam"},
+		{TeamID: 12, Name: "BBall Beta", DisplayName: "BBall Beta Wildcats", Abbreviation: "BBB", Location: "BBall Beta", Slug: "bball-beta", IsActive: true, Sport: "ncaam"},
+		{TeamID: 13, Name: "BBall Gamma", DisplayName: "BBall Gamma Eagles", Abbreviation: "BBG", Location: "BBall Gamma", Slug: "bball-gamma", IsActive: true, Sport: "ncaam"},
+		{TeamID: 14, Name: "BBall Delta", DisplayName: "BBall Delta Hawks", Abbreviation: "BBD", Location: "BBall Delta", Slug: "bball-delta", IsActive: true, Sport: "ncaam"},
 	}
 	if err := db.Create(&teamNames).Error; err != nil {
 		t.Fatalf("seed basketball team_names: %v", err)
 	}
 
 	teamSeasons := []database.TeamSeason{
-		{TeamID: 11, Year: 2024, FBS: 1, Conf: "Big East", Sport: "ncaambb"},
-		{TeamID: 12, Year: 2024, FBS: 1, Conf: "Big East", Sport: "ncaambb"},
-		{TeamID: 13, Year: 2024, FBS: 1, Conf: "ACC", Sport: "ncaambb"},
-		{TeamID: 14, Year: 2024, FBS: 1, Conf: "ACC", Sport: "ncaambb"},
+		{TeamID: 11, Year: 2024, FBS: 1, Conf: "Big East", Sport: "ncaam"},
+		{TeamID: 12, Year: 2024, FBS: 1, Conf: "Big East", Sport: "ncaam"},
+		{TeamID: 13, Year: 2024, FBS: 1, Conf: "ACC", Sport: "ncaam"},
+		{TeamID: 14, Year: 2024, FBS: 1, Conf: "ACC", Sport: "ncaam"},
 	}
 	if err := db.Create(&teamSeasons).Error; err != nil {
 		t.Fatalf("seed basketball team_seasons: %v", err)
@@ -310,19 +310,19 @@ func seedBasketballGames(t *testing.T, db *gorm.DB) {
 		{
 			GameID: bbFixtureGameID1, Season: 2024, Week: 10,
 			HomeID: 11, AwayID: 12, HomeScore: 78, AwayScore: 65,
-			ConfGame: true, Sport: "ncaambb",
+			ConfGame: true, Sport: "ncaam",
 			StartTime: time.Date(2024, 1, 6, 19, 0, 0, 0, time.UTC),
 		},
 		{
 			GameID: bbFixtureGameID2, Season: 2024, Week: 10,
 			HomeID: 13, AwayID: 14, HomeScore: 70, AwayScore: 68,
-			ConfGame: true, Sport: "ncaambb",
+			ConfGame: true, Sport: "ncaam",
 			StartTime: time.Date(2024, 1, 6, 19, 0, 0, 0, time.UTC),
 		},
 		{
 			GameID: bbFixtureGameID4, Season: 2024, Week: 11,
 			HomeID: 11, AwayID: 13, HomeScore: 80, AwayScore: 75,
-			Sport: "ncaambb",
+			Sport: "ncaam",
 			StartTime: time.Date(2024, 1, 13, 19, 0, 0, 0, time.UTC),
 		},
 	}
@@ -346,8 +346,8 @@ func TestBasketball_UpdateSingleGame(t *testing.T) {
 	if err := u.DB.Where("game_id = ?", bbFixtureGameID1).First(&game).Error; err != nil {
 		t.Fatalf("game not found: %v", err)
 	}
-	if game.Sport != "ncaambb" {
-		t.Errorf("Sport = %q, want %q", game.Sport, "ncaambb")
+	if game.Sport != "ncaam" {
+		t.Errorf("Sport = %q, want %q", game.Sport, "ncaam")
 	}
 	if game.HomeScore != 78 || game.AwayScore != 65 {
 		t.Errorf("scores = %d-%d, want 78-65", game.HomeScore, game.AwayScore)
@@ -403,8 +403,8 @@ func TestBasketball_UpdateCurrentWeek(t *testing.T) {
 	var games []database.Game
 	u.DB.Find(&games)
 	for _, g := range games {
-		if g.Sport != "ncaambb" {
-			t.Errorf("game %d Sport = %q, want %q", g.GameID, g.Sport, "ncaambb")
+		if g.Sport != "ncaam" {
+			t.Errorf("game %d Sport = %q, want %q", g.GameID, g.Sport, "ncaam")
 		}
 	}
 
@@ -443,8 +443,8 @@ func TestBasketball_UpdateTeamSeasons(t *testing.T) {
 		if s.FBS != 1 {
 			t.Errorf("team %d FBS = %d, want 1 (all D1 basketball)", s.TeamID, s.FBS)
 		}
-		if s.Sport != "ncaambb" {
-			t.Errorf("team %d Sport = %q, want %q", s.TeamID, s.Sport, "ncaambb")
+		if s.Sport != "ncaam" {
+			t.Errorf("team %d Sport = %q, want %q", s.TeamID, s.Sport, "ncaam")
 		}
 	}
 }
@@ -467,13 +467,13 @@ func TestBasketball_RankingForWeek(t *testing.T) {
 		t.Fatal("no ranking results found")
 	}
 
-	// All basketball results should have Fbs=true and Sport="ncaambb"
+	// All basketball results should have Fbs=true and Sport="ncaam"
 	for _, r := range results {
 		if !r.Fbs {
 			t.Errorf("team %d Fbs = false, want true (basketball single D1 ranking)", r.TeamID)
 		}
-		if r.Sport != "ncaambb" {
-			t.Errorf("team %d Sport = %q, want %q", r.TeamID, r.Sport, "ncaambb")
+		if r.Sport != "ncaam" {
+			t.Errorf("team %d Sport = %q, want %q", r.TeamID, r.Sport, "ncaam")
 		}
 		if r.FinalRank == 0 {
 			t.Errorf("team %d has FinalRank 0", r.TeamID)
@@ -500,11 +500,11 @@ func TestBasketball_UpdateRecentJSON(t *testing.T) {
 		t.Fatalf("UpdateRecentJSON: %v", err)
 	}
 
-	// Verify ncaambb/ prefix on expected files
+	// Verify ncaam/ prefix on expected files
 	expectedFiles := []string{
-		"ncaambb/availRanks.json",
-		"ncaambb/gameCount.json",
-		"ncaambb/latest.json",
+		"ncaam/availRanks.json",
+		"ncaam/gameCount.json",
+		"ncaam/latest.json",
 	}
 	for _, f := range expectedFiles {
 		if !cw.hasFile(f) {
@@ -512,15 +512,15 @@ func TestBasketball_UpdateRecentJSON(t *testing.T) {
 		}
 	}
 
-	// Verify ranking files use ncaambb/ prefix and d1 division
-	// Pattern: ncaambb/ranking/YEAR/d1/WEEK.json
+	// Verify ranking files use ncaam/ prefix and d1 division
+	// Pattern: ncaam/ranking/YEAR/d1/WEEK.json
 	if cw.fileCount() < len(expectedFiles) {
 		t.Errorf("total files = %d, want at least %d", cw.fileCount(), len(expectedFiles))
 	}
 
 	// Should NOT have fbs or fcs divisions
 	for fileName := range cw.data {
-		if fileName == "ncaambb/ranking" {
+		if fileName == "ncaam/ranking" {
 			continue
 		}
 		// Check that no ncaaf files were written


### PR DESCRIPTION
## Summary
- Renames the basketball sport identifier from `ncaambb` to `ncaam` across all source code, tests, CLI subcommands, and documentation
- Aligns with standard abbreviations and leaves room for `ncaaw` (women's basketball) in the future
- Adds a data migration (`db/migration_rename_ncaambb.sql`) that updates the `sport` column in all 4 shared tables, dropping and re-adding the `team_week_results` FK constraint to avoid violations during the rename

## Rollback plan
Run the inverse migration: `UPDATE <table> SET sport = 'ncaambb' WHERE sport = 'ncaam'` on all 4 tables (with the same FK drop/re-add pattern). No data is lost — only the string value changes.

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./...` all tests pass
- [x] `golangci-lint run` — 0 issues
- [x] `grep -r ncaambb` — only appears in historical migration files and the new migration's `WHERE` clauses
- [ ] Run migration against populated database and verify `sport` values updated
- [ ] `docker compose up` passes