### PR TITLE
Print ranker duration to stderr instead of stdout

### DIFF
--- a/cmd/ranker/main.go
+++ b/cmd/ranker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -78,7 +79,7 @@ func sportRankCmd(db *gorm.DB, sport string, hasFCS bool) *cobra.Command {
 			} else {
 				r.PrintRankings(div, top)
 			}
-			fmt.Println(duration) //nolint:forbidigo // allow
+			fmt.Fprintf(os.Stderr, "%s\n", duration)
 			return nil
 		},
 	}

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -68,14 +68,14 @@ and the fallback methods.
 
 See `internal/espn/request.go:58-79`.
 
-### `fmt.Println` in ranker CLI for error and duration output
-
-`cmd/ranker/main.go` prints `err` (which may be `nil`) and `duration` via
-`fmt.Println` with `//nolint:forbidigo` suppression. Printing a nil error
-produces a confusing `<nil>` line. The error should be checked and the duration
-should use structured output or be omitted.
-
 ## Resolved
+
+### `fmt.Println` in ranker CLI for error and duration output (resolved 2026-02-16)
+
+Changed duration output from `fmt.Println` to `fmt.Fprintf(os.Stderr, ...)` so
+it doesn't mix with ranking table output on stdout and no longer needs a
+`forbidigo` nolint directive. The nil-error print was already fixed in a prior
+change (error is checked and returned before reaching the print).
 
 ### Remove JSON export from the updater (resolved 2026-02-16)
 


### PR DESCRIPTION
## Summary
- Changed `fmt.Println(duration)` to `fmt.Fprintf(os.Stderr, "%s\n", duration)` so duration output doesn't mix with ranking table on stdout
- Removes the `forbidigo` nolint directive (no longer needed for `fmt.Fprintf`)
- Resolves the last active tech debt item in `docs/tech-debt.md`

## Test plan
- [x] `go build ./cmd/ranker/` succeeds
- [x] `golangci-lint run --config=.golangci.yml ./cmd/ranker/` passes with 0 issues