### PR TITLE
Add post-rankings deploy hook for stats-web

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -4,3 +4,10 @@ PG_USER: postgres
 PG_PASSWORD: postgres
 PG_DBNAME: defaultdb
 PG_SSLMODE: disable
+
+# Optional: trigger a stats-web build+deploy after rankings update
+# DEPLOY_SCRIPT defaults to /scripts/deploy-web.sh inside the container
+DEPLOY_SCRIPT=
+CF_PAGES_PROJECT=
+CLOUDFLARE_API_TOKEN=
+CLOUDFLARE_ACCOUNT_ID=

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,15 @@ ADD cmd ./cmd
 ADD internal ./internal
 RUN go build -o updater ./cmd/updater
 
-FROM alpine:latest as updater
+FROM node:24-alpine AS updater
 WORKDIR /
 
-RUN apk add --no-cache tzdata
+RUN apk add --no-cache tzdata git
 ENV TZ=America/New_York
+RUN corepack enable
+
+COPY scripts/deploy-web.sh /scripts/deploy-web.sh
+RUN chmod +x /scripts/deploy-web.sh
 
 COPY --from=builder /app/updater .
 ENTRYPOINT ["/updater", "schedule"]

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"os/signal"
 	"syscall"
 	"time"
@@ -37,7 +39,7 @@ func main() {
 	}
 	rootCmd.SilenceUsage = true
 
-	scheduleCmd := scheduleCommand(log, db)
+	scheduleCmd := scheduleCommand(log, db, cfg.DeployScript)
 	ncaafCmd := sportCommand(log, db, espn.CollegeFootball)
 	ncaamCmd := sportCommand(log, db, espn.CollegeBasketball)
 
@@ -58,6 +60,53 @@ func newUpdater(
 	}
 }
 
+// deployer runs a deploy script in the background after rankings are updated.
+// Calls to Trigger are coalesced: if a deploy is already queued, extra triggers
+// are dropped so at most one deploy is pending at a time.
+type deployer struct {
+	script  string
+	log     *zap.SugaredLogger
+	trigger chan struct{}
+}
+
+func newDeployer(log *zap.SugaredLogger, script string) *deployer {
+	d := &deployer{
+		script:  script,
+		log:     log,
+		trigger: make(chan struct{}, 1),
+	}
+	go d.run()
+	return d
+}
+
+// Trigger enqueues a deploy. If one is already pending, this is a no-op.
+func (d *deployer) Trigger() {
+	if d.script == "" {
+		return
+	}
+	select {
+	case d.trigger <- struct{}{}:
+	default:
+	}
+}
+
+func (d *deployer) stop() {
+	close(d.trigger)
+}
+
+func (d *deployer) run() {
+	for range d.trigger {
+		//nolint:gosec // DEPLOY_SCRIPT is operator-supplied config, not user input
+		cmd := exec.CommandContext(context.Background(), d.script)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			d.log.Errorf("deploy script failed: %v\n%s", err, out)
+			continue
+		}
+		d.log.Infof("deploy script completed:\n%s", out)
+	}
+}
+
 // sportSchedule holds the cron expressions for a sport's scheduled jobs.
 type sportSchedule struct {
 	Name          string // human-readable label for log messages
@@ -72,6 +121,7 @@ func (ss sportSchedule) registerJobs(
 	s gocron.Scheduler,
 	log *zap.SugaredLogger,
 	u updater.Updater,
+	d *deployer,
 ) func() {
 	update := make(chan bool, 1)
 	stop := make(chan bool, 1)
@@ -92,6 +142,7 @@ func (ss sportSchedule) registerJobs(
 						return
 					}
 					log.Infof("%s rankings updated", ss.Name)
+					d.Trigger()
 				}()
 			case <-stop:
 				return
@@ -162,6 +213,7 @@ func (ss sportSchedule) registerJobs(
 func scheduleCommand(
 	log *zap.SugaredLogger,
 	db *gorm.DB,
+	deployScript string,
 ) *cobra.Command {
 	return &cobra.Command{
 		Use:   "schedule",
@@ -171,6 +223,8 @@ func scheduleCommand(
 			if err != nil {
 				panic(err)
 			}
+
+			d := newDeployer(log, deployScript)
 
 			sports := []struct {
 				schedule sportSchedule
@@ -199,7 +253,7 @@ func scheduleCommand(
 			var stopFuncs []func()
 			for _, sp := range sports {
 				u := newUpdater(log, db, sp.sport)
-				stopFn := sp.schedule.registerJobs(s, log, u)
+				stopFn := sp.schedule.registerJobs(s, log, u, d)
 				stopFuncs = append(stopFuncs, stopFn)
 			}
 
@@ -215,6 +269,7 @@ func scheduleCommand(
 			for _, fn := range stopFuncs {
 				fn()
 			}
+			d.stop()
 
 			return nil
 		},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,12 @@ services:
       PG_USER: ${PG_USER}
       PG_PASSWORD: ${PG_PASSWORD}
       PG_DBNAME: ${PG_DBNAME}
-      PG_SSLMODE: ${PG_SSLMODE} 
+      PG_SSLMODE: ${PG_SSLMODE}
       TZ: ${TZ:-America/New_York}
+      DEPLOY_SCRIPT: ${DEPLOY_SCRIPT:-/scripts/deploy-web.sh}
+      CF_PAGES_PROJECT: ${CF_PAGES_PROJECT}
+      CLOUDFLARE_API_TOKEN: ${CLOUDFLARE_API_TOKEN}
+      CLOUDFLARE_ACCOUNT_ID: ${CLOUDFLARE_ACCOUNT_ID}
     depends_on:
       db:
         condition: service_healthy

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,9 +10,9 @@ import (
 )
 
 type Config struct {
-	Env              string
-	DBParams         *database.DBParams
-	RevalidateSecret string
+	Env          string
+	DBParams     *database.DBParams
+	DeployScript string
 }
 
 func SetupConfig() *Config {
@@ -35,6 +35,6 @@ func SetupConfig() *Config {
 			DBName:   os.Getenv("PG_DBNAME"),
 			SSLMode:  os.Getenv("PG_SSLMODE"),
 		},
-		RevalidateSecret: os.Getenv("REVALIDATE_SECRET"),
+		DeployScript: os.Getenv("DEPLOY_SCRIPT"),
 	}
 }

--- a/scripts/deploy-web.sh
+++ b/scripts/deploy-web.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+git clone https://github.com/robby-barton/stats-web.git "$WORK_DIR"
+cd "$WORK_DIR"
+
+export DATABASE_URL="postgresql://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/${PG_DBNAME}"
+
+yarn install --frozen-lockfile
+yarn build
+npx wrangler pages deploy _site/ --project-name "${CF_PAGES_PROJECT}"


### PR DESCRIPTION
## Summary

- Adds an optional `DEPLOY_SCRIPT` env var that, when set, is executed after each successful rankings update
- Implements a `deployer` struct with a buffered channel so concurrent ranking updates coalesce into at most one pending deploy
- Provides `scripts/deploy-web.sh` which clones stats-web, builds it with yarn, and deploys to Cloudflare Pages via wrangler
- Swaps the unused `RevalidateSecret` config field for `DeployScript`
- Upgrades Dockerfile base image from `alpine` to `node:24-alpine` and installs `git` + `corepack` so the deploy script can run inside the container

## API / Config contract

No API changes. New optional env vars (all no-op if unset):

| Var | Purpose |
|-----|---------|
| `DEPLOY_SCRIPT` | Path to deploy script (default `/scripts/deploy-web.sh` in container) |
| `CF_PAGES_PROJECT` | Cloudflare Pages project name |
| `CLOUDFLARE_API_TOKEN` | Cloudflare API token for wrangler |
| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID |

## Test plan

- [ ] `docker compose up` succeeds with and without `DEPLOY_SCRIPT` set
- [ ] Rankings update without `DEPLOY_SCRIPT` set — no deploy attempt, no errors
- [ ] Rankings update with `DEPLOY_SCRIPT` set to a test script — script executes once after update
- [ ] Two concurrent ranking updates with `DEPLOY_SCRIPT` set — only one deploy fires (coalescing verified via logs)
- [ ] `go test ./...` passes
- [ ] `golangci-lint run` passes