### PR TITLE
Tune sport-specific final ranking weights via exhaustive grid search

### DIFF
--- a/internal/ranking/ranking.go
+++ b/internal/ranking/ranking.go
@@ -28,15 +28,24 @@ type sportParams struct {
 	RequiredGames int
 	YearsBack     int64
 	MOVCaps       []int64
+	RecordWeight  float64
+	SRSWeight     float64
+	SOSWeight     float64
 }
 
 // sportConfig returns ranking constants appropriate for the sport.
 func (r *Ranker) sportConfig() sportParams {
 	switch r.Sport {
 	case sportBasketball:
-		return sportParams{RequiredGames: 25, YearsBack: 1, MOVCaps: []int64{1, 20}}
+		return sportParams{
+			RequiredGames: 25, YearsBack: 1, MOVCaps: []int64{1, 20},
+			RecordWeight: 0.25, SRSWeight: 0.60, SOSWeight: 0.15,
+		}
 	case sportFootball:
-		return sportParams{RequiredGames: 12, YearsBack: 2, MOVCaps: []int64{1, 30}}
+		return sportParams{
+			RequiredGames: 12, YearsBack: 2, MOVCaps: []int64{1, 30},
+			RecordWeight: 0.45, SRSWeight: 0.40, SOSWeight: 0.15,
+		}
 	default:
 		panic(fmt.Sprintf("unknown sport: %q", r.Sport))
 	}
@@ -127,8 +136,11 @@ func (r *Ranker) CalculateRanking() (TeamList, error) {
 }
 
 func (r *Ranker) finalRanking(teamList TeamList) {
+	cfg := r.sportConfig()
 	for _, team := range teamList {
-		team.FinalRaw = (team.Record.Record * 0.60) + (team.SRSNorm * 0.30) + (team.SOSNorm * 0.10)
+		team.FinalRaw = (team.Record.Record * cfg.RecordWeight) +
+			(team.SRSNorm * cfg.SRSWeight) +
+			(team.SOSNorm * cfg.SOSWeight)
 	}
 
 	var ids []int64

--- a/internal/ranking/ranking_test.go
+++ b/internal/ranking/ranking_test.go
@@ -76,12 +76,12 @@ func TestFinalRanking_Basic(t *testing.T) {
 		},
 	}
 
-	r := &Ranker{}
+	r := &Ranker{Sport: sportFootball}
 	r.finalRanking(teamList)
 
-	// Alpha: 1.0*0.60 + 1.0*0.30 + 0.8*0.10 = 0.98
-	// Beta: 0.667*0.60 + 0.5*0.30 + 0.6*0.10 = 0.6102
-	// Gamma: 0.5*0.60 + 0.3*0.30 + 0.4*0.10 = 0.43
+	// Alpha: 1.0*0.45 + 1.0*0.40 + 0.8*0.15 = 0.97
+	// Beta: 0.667*0.45 + 0.5*0.40 + 0.6*0.15 = 0.590
+	// Gamma: 0.5*0.45 + 0.3*0.40 + 0.4*0.15 = 0.405
 
 	if teamList[1].FinalRank != 1 {
 		t.Errorf("Alpha FinalRank = %d, want 1", teamList[1].FinalRank)
@@ -94,7 +94,7 @@ func TestFinalRanking_Basic(t *testing.T) {
 	}
 
 	// Verify FinalRaw calculation for Alpha
-	expectedRaw := 1.0*0.60 + 1.0*0.30 + 0.8*0.10
+	expectedRaw := 1.0*0.45 + 1.0*0.40 + 0.8*0.15
 	if math.Abs(teamList[1].FinalRaw-expectedRaw) > 0.001 {
 		t.Errorf("Alpha FinalRaw = %f, want %f", teamList[1].FinalRaw, expectedRaw)
 	}
@@ -122,7 +122,7 @@ func TestFinalRanking_TiedScores(t *testing.T) {
 		},
 	}
 
-	r := &Ranker{}
+	r := &Ranker{Sport: sportFootball}
 	r.finalRanking(teamList)
 
 	// Teams A and B have identical FinalRaw, so they should share the same rank


### PR DESCRIPTION
## Summary

- Adds `RecordWeight`, `SRSWeight`, `SOSWeight` fields to `sportParams` so each sport has independently calibrated final ranking weights
- Replaces the single hardcoded formula (`Record×0.60 + SRS×0.30 + SOS×0.10`) with a per-sport config lookup in `finalRanking()`
- Fixes two unit tests that used bare `&Ranker{}` (no `Sport` field), which would panic after the config lookup was added

## Weight Selection Methodology

Weights were selected by an exhaustive grid search:
1. Run the ranker 3× with orthogonal weights (100/0/0, 0/100/0, 0/0/100) to extract each team's underlying normalized Record, SRS, and SOS component values
2. Enumerate all 153 valid weight combinations at 5% steps (each component ≥5%, sum=100%)
3. Simulate rankings for every combination and compute **mean absolute rank difference (MARD)** against the AP poll
4. Select the global minimum

## Results

| Sport | Weights (Rec/SRS/SOS) | MARD | vs prior |
|-------|----------------------|------|---------|
| ncaam | 0.25 / 0.60 / 0.15 | 2.56 | ↓ from ~2.93 (initial 0.35/0.50/0.15 target) |
| ncaaf | 0.45 / 0.40 / 0.15 | 2.60 | ↓ from 3.24 (prior 0.60/0.30/0.10) |

**ncaam:** Shifting weight toward SRS corrects for conference quality — strong-conference teams (Florida, Illinois, Kansas) rank higher; weak-conference record-padders (Gonzaga, Saint Mary's, Utah State) rank lower. 25/60/15 is tied for the global optimum with 20/75/5 and 25/65/10; chosen as the most balanced of the three.

**ncaaf:** 45/40/15 is the global optimum for the final-week vs final AP poll comparison, and only 0.04 MARD off the best for a pre-bowl week vs pre-bowl AP poll comparison (1.80 vs best possible 1.76). The higher pre-bowl MARD floor reflects that post-CFP polls reward playoff performance in ways SRS-based rankings cannot replicate.

## Test Plan

- [ ] `go test ./internal/ranking/...` passes
- [ ] `go run ./cmd/ranker ncaam -y 2026 -w 19 -t 25` — confirm weak-conference teams (Gonzaga, Saint Mary's) rank lower than original; Florida/Illinois rank higher
- [ ] `go run ./cmd/ranker ncaaf -y 2025 -w 999 -t 25` — confirm Indiana #1, top 10 broadly matches final AP poll
- [ ] `docker compose up` stack healthy