### PR TITLE
Sync docs with current codebase state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -125,7 +125,7 @@ defaults to football and uses package-level URL vars (overridable in tests via
 
 ## Database
 
-14 GORM models covering teams, games, and player statistics. Supports both
+19 GORM models covering teams, games, and player statistics. Supports both
 PostgreSQL (production) and SQLite (local development). Connection is determined
 by whether `DBParams` is nil (nil → SQLite).
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # College Sports Computer Ranking
 
-A Go application that pulls game data from the ESPN API, computes SRS/SOS
-composite rankings for college football and basketball teams, and exports
-results to DigitalOcean Spaces.
+A Go application that pulls game data from the ESPN API and computes SRS/SOS
+composite rankings for college football and basketball teams.
 
 ## Overview
 
@@ -10,7 +9,7 @@ The system consists of two CLI tools:
 
 - **Ranker** — calculates and prints rankings for a given year/week
 - **Updater** — scheduled service that fetches games, updates the database,
-  computes rankings, and exports JSON to a CDN
+  and computes rankings
 
 Rankings use a composite algorithm based on Simple Rating System (SRS) and
 Strength of Schedule (SOS). Football supports both FBS and FCS divisions;
@@ -27,7 +26,7 @@ basketball ranks D1 teams.
 ### Setup
 
 ```sh
-cp .env-sample .env   # configure database and DigitalOcean credentials
+cp .env-sample .env   # configure database credentials
 make modules          # sync Go module dependencies
 ```
 
@@ -38,6 +37,7 @@ Set in `.env` (see `.env-sample` for the full list):
 | Variable | Description |
 |----------|-------------|
 | `PG_HOST`, `PG_PORT`, `PG_USER`, `PG_PASSWORD`, `PG_DBNAME`, `PG_SSLMODE` | PostgreSQL connection (omit all to use SQLite) |
+| `DEPLOY_SCRIPT` | Path to a script run after each ranking update (optional) |
 
 ## Usage
 
@@ -82,8 +82,6 @@ make updater OPTS="football ranking"                # update current football ra
 make updater OPTS="football ranking --all"          # update all football rankings
 make updater OPTS="football teams"                  # update football team info
 make updater OPTS="football season"                 # update football season info
-make updater OPTS="football json"                   # rewrite current football JSON
-make updater OPTS="football json --all"             # rewrite all football JSON
 make updater OPTS="basketball games --all"          # update all basketball games
 make updater OPTS="basketball ranking"              # update basketball rankings
 ```
@@ -95,7 +93,6 @@ make updater OPTS="basketball ranking"              # update basketball rankings
 | | `ranking` | `--all` | Update rankings (current season by default) |
 | | `teams` | | Update team info from ESPN |
 | | `season` | | Update season info |
-| | `json` | `--all` | Rewrite JSON output (current season by default) |
 
 ## Development
 
@@ -112,7 +109,7 @@ make format           # go fmt
 ```
 cmd/
   ranker/             CLI: calculate and print rankings
-  updater/            CLI: fetch games, update DB, export JSON
+  updater/            CLI: fetch games, update DB, compute rankings
   migrate/            CLI: one-time migration from PostgreSQL to SQLite
 internal/
   config/             Environment-based configuration (godotenv)
@@ -122,8 +119,7 @@ internal/
   logger/             Structured logging (zap)
   ranking/            Ranking algorithm (SRS, SOS, composite scoring)
   team/               Team info parsing from ESPN
-  updater/            Orchestration of DB updates and JSON export
-  writer/             Output interface (DigitalOcean Spaces or local files)
+  updater/            Orchestration of DB updates and ranking computation
 ```
 
 ## Deployment

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1,25 +1,26 @@
 # Design Decisions
 
-## Ranking Algorithm: 60/30/10 Composite
+## Ranking Algorithm: Sport-Specific Composite
 
 The final ranking uses a weighted composite score:
 
 ```
-FinalRaw = (Record * 0.60) + (SRS_normalized * 0.30) + (SOS_normalized * 0.10)
+FinalRaw = (Record * RecordWeight) + (SRS_normalized * SRSWeight) + (SOS_normalized * SOSWeight)
 ```
 
-- **60% Win-Loss Record** — The most important factor. Teams that win more
-  games should rank higher.
-- **30% SRS (Simple Rating System)** — An iterative margin-of-victory rating
+- **Win-Loss Record** — Winning more games is the primary signal for football;
+  less dominant for basketball where margin matters more.
+- **SRS (Simple Rating System)** — An iterative margin-of-victory rating
   adjusted for opponent strength. Run with two margin-of-victory caps and
   averaged. The dual-MOV approach balances "did you win?" with "did you
   dominate?" while preventing blowouts from distorting ratings. Iterates up to
   10,000 times or until convergence.
-- **10% SOS (Strength of Schedule)** — Solved via Cholesky decomposition of a
+- **SOS (Strength of Schedule)** — Solved via Cholesky decomposition of a
   system of linear equations. Measures quality of opponents independent of the
   team's own performance.
 
-All component scores are min-max normalized to [0,1] before weighting.
+All component scores are min-max normalized to [0,1] before weighting. Weights
+were tuned independently per sport via exhaustive grid search.
 
 ### Sport-Specific Constants
 
@@ -28,6 +29,9 @@ tuning parameters:
 
 | Parameter | Football | Basketball | Rationale |
 |-----------|----------|------------|-----------|
+| `RecordWeight` | 0.45 | 0.25 | Football results are more outcome-driven; basketball rewards margin |
+| `SRSWeight` | 0.40 | 0.60 | SRS is more predictive in basketball's higher-volume schedule |
+| `SOSWeight` | 0.15 | 0.15 | Equal schedule-strength influence across sports |
 | `requiredGames` | 12 | 25 | Basketball plays ~30 games/season vs ~12 for football |
 | `yearsBack` | 2 | 1 | Basketball has more games, less need for historical backfill |
 | MOV caps | [1, 30] | [1, 20] | Basketball has narrower score variance |
@@ -98,16 +102,14 @@ Key design choices:
 - **URL vars as fallback** — ESPN endpoint URLs are `var` not `const`
   so tests can override them with a mock HTTP server.
 
-## Writer Interface for Output
+## Post-Rankings Deploy Hook
 
-Rather than hardcoding DigitalOcean Spaces, output goes through a `Writer`
-interface. This allows:
-- Production: gzipped JSON uploaded to DO Spaces with CDN cache purging
-- Local dev: plain JSON files written to disk
-- Testing: mock writers
-
-JSON output paths are sport-prefixed (`ncaaf/ranking/...`, `ncaam/ranking/...`) to
-keep football and basketball data separate in the output bucket.
+After each ranking update, the updater optionally triggers a deploy script
+configured via the `DEPLOY_SCRIPT` environment variable. The deployer runs in a
+background goroutine with a buffered channel of size 1. Multiple ranking updates
+in quick succession coalesce into a single deploy — if one is already queued,
+extra triggers are dropped. This prevents deploy storms during rapid back-to-back
+ranking runs. If `DEPLOY_SCRIPT` is empty, the hook is a no-op.
 
 ## Scheduled Updates During Season
 


### PR DESCRIPTION
## Summary

- **README**: remove stale JSON export / `writer/` package references (removed in #85), add `DEPLOY_SCRIPT` env var (added in #88), fix updater description
- **ARCHITECTURE**: correct GORM model count (14 → 19)
- **docs/design-decisions**: update ranking weights to the sport-specific values tuned in #89 (football 45/40/15, basketball 25/60/15); replace stale Writer Interface section with Post-Rankings Deploy Hook (#88)

No code changes.